### PR TITLE
Support for ESP_IDF builds based on CMake. Also allows for compilatio…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16.0)
+
+if (NOT DEFINED PROJECT_NAME)
+    include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+    project(esp_littlefs)
+else ()
+    file(GLOB_RECURSE SOURCES src/*.cpp)
+    idf_component_register(SRCS ${SOURCES} INCLUDE_DIRS src)
+endif (NOT DEFINED PROJECT_NAME)


### PR DESCRIPTION
Using the component as is does not work with the new CMake based ESP-IDF within PlatformIO. The added CMakeList.txt allows the component to be detected by the build system while still allowing building the project in a standalone way (for testing purpose).