### PR TITLE
Support for ESP_IDF CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,10 @@ if (NOT DEFINED PROJECT_NAME)
     include($ENV{IDF_PATH}/tools/cmake/project.cmake)
     project(esp_littlefs)
 else ()
-    file(GLOB_RECURSE SOURCES src/*.cpp)
-    idf_component_register(SRCS ${SOURCES} INCLUDE_DIRS src)
+    file(GLOB SOURCES src/littlefs/*.c)
+    list(APPEND SOURCES src/esp_littlefs.c src/littlefs_api.c)
+    idf_component_register(
+        SRCS ${SOURCES}
+        INCLUDE_DIRS src include
+        REQUIRES spi_flash)
 endif (NOT DEFINED PROJECT_NAME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.16.0)
+
+if (NOT DEFINED PROJECT_NAME)
+    include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+    project(esp_littlefs)
+else ()
+    file(GLOB_RECURSE SOURCES src/*.cpp)
+    idf_component_register(SRCS ${SOURCES} INCLUDE_DIRS src)
+endif (NOT DEFINED PROJECT_NAME)

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -8,7 +8,6 @@
 
 #include "esp_log.h"
 #include "esp_spi_flash.h"
-#include "esp_image_format.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/semphr.h"

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -56,6 +56,7 @@ static long    vfs_littlefs_telldir(void* ctx, DIR* pdir);
 static void    vfs_littlefs_seekdir(void* ctx, DIR* pdir, long offset);
 static int     vfs_littlefs_mkdir(void* ctx, const char* name, mode_t mode);
 static int     vfs_littlefs_rmdir(void* ctx, const char* name);
+static int     vfs_littlefs_fsync(void* ctx, int fd);
 static int     vfs_littlefs_utime(void *ctx, const char *path, const struct utimbuf *times);
 
 static esp_err_t esp_littlefs_init(const esp_vfs_littlefs_conf_t* conf);
@@ -131,6 +132,7 @@ esp_err_t esp_vfs_littlefs_register(const esp_vfs_littlefs_conf_t * conf)
         .telldir_p   = &vfs_littlefs_telldir,
         .mkdir_p     = &vfs_littlefs_mkdir,
         .rmdir_p     = &vfs_littlefs_rmdir,
+        .fsync_p     = &vfs_littlefs_fsync,
 #ifdef CONFIG_LITTLEFS_USE_MTIME
         .utime_p     = &vfs_littlefs_utime,
 #else
@@ -1141,6 +1143,31 @@ static int vfs_littlefs_rmdir(void* ctx, const char* name) {
     }
 
     return 0;
+}
+
+static int vfs_littlefs_fsync(void* ctx, int fd)
+{
+    esp_littlefs_t * efs = (esp_littlefs_t *)ctx;
+    ssize_t res;
+    vfs_littlefs_file_t *file = NULL;
+
+    if(fd > ABSOLUTE_MAX_NUM_FILES || fd < 0) {
+        ESP_LOGE(TAG, "FD must be <%d.", ABSOLUTE_MAX_NUM_FILES);
+        return LFS_ERR_BADF;
+    }
+
+    sem_take(efs);
+    file = &efs->files[fd];
+    res = lfs_file_sync(efs->fs, &file->file);
+    sem_give(efs);
+
+    if(res < 0){
+        ESP_LOGE(TAG, "Failed to sync file \"%s\". Error %s (%d)",
+                file->path, esp_littlefs_errno(res), res);
+        return res;
+    }
+
+    return res;
 }
 
 /**


### PR DESCRIPTION
Using the component as is does not work with the new CMake based ESP-IDF within PlatformIO. The added CMakeList.txt allows the component to be detected by the build system while still allowing building the project in a standalone way (for testing purpose).