### PR TITLE
Update LittleFS, fix some memory leaks and remove limits to number of opened files

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -66,6 +66,12 @@ menu "LittleFS"
         default "y"
         help
             Saves timestamp on modification. Uses an additional 4bytes.
+    
+    config LITTLEFS_USE_ONLY_HASH
+        bool "Only remember a hash insted of a file path in the file descriptor"
+        default "y"
+        help
+            Saves heap memory but might cause files to prevent unlinking or renaming upon (unlikely) hash collision.
 
     choice LITTLEFS_MTIME
         prompt "mtime attribute options"

--- a/README.md
+++ b/README.md
@@ -67,12 +67,6 @@ LittleFS:    32,827 us
 ```
 
 
-# Limitations
-
-Currently only an absolute maximum of *20* files can be opened at once. This can be
-increased by increasing the `esp_littlefs_t.fd_used` bitmask to a larger datatype, 
-and changing `ABSOLUTE_MAX_NUM_FILES`. 
-
 # Tips, Tricks, and Gotchas
 
 * LittleFS operates on blocks, and blocks have a size of 4096 bytes on the ESP32.

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -36,7 +36,6 @@ enum {
 typedef struct {
     const char *base_path;            /**< Mounting point. */
     const char *partition_label;      /**< Label of partition to use. */
-    uint8_t max_files;                /**< Maximum files that could be open at the same time. */
     uint8_t format_if_mount_failed:1; /**< Format the file system if it fails to mount. */
     uint8_t dont_mount:1;             /**< Don't attempt to mount or format. Overrides format_if_mount_failed */
 } esp_vfs_littlefs_conf_t;

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -99,11 +99,13 @@ esp_err_t esp_littlefs_format(const char* partition_label);
  */
 esp_err_t esp_littlefs_info(const char* partition_label, size_t *total_bytes, size_t *used_bytes);
 
+#ifndef CONFIG_LITTLEFS_USE_ONLY_HASH
 /**
  * @brief converts an enumerated lfs error into a string.
  * @param lfs_errno The enumerated littlefs error.
  */
 const char * esp_littlefs_errno(enum lfs_error lfs_errno);
+#endif
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -22,7 +22,9 @@ typedef struct _vfs_littlefs_file_t {
     lfs_file_t file;
     uint32_t   hash;
     struct _vfs_littlefs_file_t * next;
+#ifndef CONFIG_LITTLEFS_USE_ONLY_HASH
     char     * path;
+#endif
 } vfs_littlefs_file_t;
 
 /**

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -14,9 +14,15 @@
 extern "C" {
 #endif
 
-typedef struct {
+/**
+ * @brief a file descriptor
+ * That's also a chained list used for keeping tracks of all opened file descriptor 
+ */
+typedef struct _vfs_littlefs_file_t {
     lfs_file_t file;
-    char path[LFS_NAME_MAX]; // TODO: dynamically allocate
+    uint32_t   hash;
+    struct _vfs_littlefs_file_t * next;
+    char     * path;
 } vfs_littlefs_file_t;
 
 /**
@@ -27,11 +33,12 @@ typedef struct {
     SemaphoreHandle_t lock;                   /*!< FS lock */
     const esp_partition_t* partition;         /*!< The partition on which littlefs is located */
     char base_path[ESP_VFS_PATH_MAX+1];       /*!< Mount point */
+
     struct lfs_config cfg;                    /*!< littlefs Mount configuration */
-    vfs_littlefs_file_t *files;               /*!< Array of files */
-    uint32_t fd_used:20;                      /*!< Mask of used file descriptors */
-    uint32_t max_files:7;                     /*!< Maximum number of file descriptors */
-    uint32_t mounted:1;                       /*!< littlefs is mounted */
+    vfs_littlefs_file_t *file;                /*!< List of files */
+    vfs_littlefs_file_t **cache;              /*!< A cache of pointers to the opened files */
+    uint16_t             cache_size;          /*!< The cache allocated size (in pointers) */
+    uint16_t             fd_count;            /*!< The count of opened file descriptor used to speed up computation */
 } esp_littlefs_t;
 
 /**

--- a/src/test/test_benchmark.c
+++ b/src/test/test_benchmark.c
@@ -61,7 +61,6 @@ static void setup_littlefs() {
     esp_vfs_littlefs_conf_t conf = {
         .base_path = "/littlefs",
         .partition_label = "flash_test",
-        .max_files = MAX_FILES,
         .format_if_mount_failed = true
     };
     TEST_ESP_OK(esp_vfs_littlefs_register(&conf));

--- a/src/test/test_littlefs.c
+++ b/src/test/test_littlefs.c
@@ -79,7 +79,6 @@ TEST_CASE("can format unmounted partition", "[littlefs]")
     esp_vfs_littlefs_conf_t conf = {
         .base_path = littlefs_base_path,
         .partition_label = littlefs_test_partition_label,
-        .max_files = 5,
         .format_if_mount_failed = false
     };
     TEST_ESP_OK(esp_vfs_littlefs_register(&conf));
@@ -106,12 +105,11 @@ TEST_CASE("can read file", "[littlefs]")
 
 TEST_CASE("can open maximum number of files", "[littlefs]")
 {
-    size_t max_files = FOPEN_MAX - 3; /* account for stdin, stdout, stderr */
+    size_t max_files = 61;  /* account for stdin, stdout, stderr, esp-idf defaults to maximum 64 file descriptors */
     const esp_vfs_littlefs_conf_t conf = {
         .base_path = littlefs_base_path,
         .partition_label = littlefs_test_partition_label,
         .format_if_mount_failed = true,
-        .max_files = max_files
     };
     TEST_ESP_OK(esp_vfs_littlefs_register(&conf));
     test_littlefs_open_max_files("/littlefs/f", max_files);
@@ -726,7 +724,6 @@ static void test_setup() {
     esp_vfs_littlefs_conf_t conf = {
         .base_path = littlefs_base_path,
         .partition_label = littlefs_test_partition_label,
-        .max_files = 5,
         .format_if_mount_failed = true
     };
     TEST_ESP_OK(esp_vfs_littlefs_register(&conf));


### PR DESCRIPTION
This is a large PR, but I can't really split it in smaller one. 
I've:

1. updated LittleFS to a new version
2. removed the max file limitation and reduced heap space used
3. made the storage of the file path optional (and selectable in menuconfig), only a hash is stored instead
4. reduced the binary footprint of the built by removing useless part in the code and string array storage
5. updated readme and tests

Just a note on how the new table of file descriptor is written:
- `lfs_file_t` is now a chained list (this is used for deallocating files upon unmounting), and it's not using a static char array anymore for storing file path (if selected in menuconfig, the file path string is allocated at the same time as the file descriptor)
- Instead of the hack with the bitcount & bitfield for file descriptors, I'm maintaining an (heap) allocated chained list of file descriptor, and a heap allocated array of pointers to the file descriptors (which is realloc'd upon larger requirement). This means that you only pay for what you use (if you use 4x fd simultaneously, it'll allocate a array with 4x `void *`). I've removed all the cruft about `fd_used` bitfield. *Do you know that bitfields are useless without `#pragma pack` because compiler will align the next field anyway so you're not saving anything here, and also generate more code than plain word usage because of required masking and shifting?*
- I've reworked the `acquire_fd`/ `free_fd` / `search_fd` so it does not need recursive mutex anymore, and also not leaking anymore upon error.
