### PR TITLE
Multi fd sync

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "main/littlefs"]
 	path = src/littlefs
-	url = https://github.com/ARMmbed/littlefs.git
+	url = https://github.com/littlefs-project/littlefs.git

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -34,6 +34,7 @@ typedef struct _vfs_littlefs_file_t {
     lfs_file_t file;
     uint32_t   hash;
     struct _vfs_littlefs_file_t * next;       /*!< Pointer to next file in Singly Linked List */
+    uint8_t open_count;  /*!< Number of times this file has been opened */
 #ifndef CONFIG_LITTLEFS_USE_ONLY_HASH
     char     * path;
 #endif

--- a/src/test/test_littlefs.c
+++ b/src/test/test_littlefs.c
@@ -906,6 +906,30 @@ static void test_littlefs_concurrent_rw(const char* filename_prefix)
 #undef TASK_SIZE
 }
 
+TEST_CASE("multiple file-descriptors sync", "[littlefs]")
+{
+    test_setup();
+
+    uint8_t buf1[1] = {'a'};
+	uint8_t buf2[1] = {};
+
+	int fd1 = open(littlefs_base_path "/file.bin", O_CREAT | O_RDWR);
+	assert(fd1 >= 0);
+
+	int fd2 = open(littlefs_base_path "/file.bin", O_RDWR);
+	assert(fd2 >= 0);
+
+	lseek(fd1, 0, SEEK_SET);
+	write(fd1, &buf1, sizeof(buf1));
+	fsync(fd1);
+
+	lseek(fd2, 0, SEEK_SET);
+	read(fd2, &buf2, sizeof(buf2));
+	assert(buf1[0] == buf2[0]); 
+
+    test_teardown();
+}
+
 
 static void test_setup() {
     const esp_vfs_littlefs_conf_t conf = {

--- a/src/test/test_littlefs.c
+++ b/src/test/test_littlefs.c
@@ -910,22 +910,31 @@ TEST_CASE("multiple file-descriptors sync", "[littlefs]")
 {
     test_setup();
 
-    uint8_t buf1[1] = {'a'};
-	uint8_t buf2[1] = {};
+    const char* filename = littlefs_base_path "/multi_fd_file.bin";
 
-	int fd1 = open(littlefs_base_path "/file.bin", O_CREAT | O_RDWR);
-	assert(fd1 >= 0);
+    /* Run this test several times, there seems to be some non-determinism */
+    for(int i=0; i < 100; i++) {
+        uint8_t buf1[1] = {'a'};
+        uint8_t buf2[1] = {};
 
-	int fd2 = open(littlefs_base_path "/file.bin", O_RDWR);
-	assert(fd2 >= 0);
+        int fd1 = open(filename, O_CREAT | O_RDWR);
+        assert(fd1 >= 0);
 
-	lseek(fd1, 0, SEEK_SET);
-	write(fd1, &buf1, sizeof(buf1));
-	fsync(fd1);
+        int fd2 = open(filename, O_RDWR);
+        assert(fd2 >= 0);
 
-	lseek(fd2, 0, SEEK_SET);
-	read(fd2, &buf2, sizeof(buf2));
-	assert(buf1[0] == buf2[0]); 
+        lseek(fd1, 0, SEEK_SET);
+        write(fd1, &buf1, sizeof(buf1));
+        fsync(fd1);
+
+        lseek(fd2, 0, SEEK_SET);
+        read(fd2, &buf2, sizeof(buf2));
+        assert(buf1[0] == buf2[0]); 
+
+        close(fd1);
+        close(fd2);
+        unlink(filename);
+    }
 
     test_teardown();
 }

--- a/src/test/test_littlefs.c
+++ b/src/test/test_littlefs.c
@@ -952,7 +952,7 @@ TEST_CASE("multiple file-descriptors sync", "[littlefs]")
     const char* filename = littlefs_base_path "/multi_fd_file.bin";
 
     /* Run this test several times, there seems to be some non-determinism */
-    for(int i=0; i < 100; i++) {
+    for(int i=0; i < 10; i++) {
         uint8_t buf1[1] = {'a'};
         uint8_t buf2[1] = {};
 


### PR DESCRIPTION
When the same file is opened multipled times, return the same FD but increment an internal counter. This will provide better compatibility for typical use-cases when the same file is opened multiple times