### PR TITLE
Spiffs compat

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -122,4 +122,16 @@ menu "LittleFS"
 
     endchoice
 
+    config LITTLEFS_SPIFFS_COMPAT
+        bool "Improve SPIFFS drop-in compatability"
+        default "n"
+        help
+            Enabling this feature allows for greater drop-in compatability
+            when replacing SPIFFS. Since SPIFFS doesn't have folders, and 
+            folders are just considered as part of a file name, enabling this
+            will automatically create folders as necessary to create a file
+            instead of throwing an error. Similarly, upon the deletion of the
+            last file in a folder, the folder will be deleted. It is recommended
+            to only enable this flag as a stop-gap solution.
+
 endmenu

--- a/src/test/test_littlefs.c
+++ b/src/test/test_littlefs.c
@@ -978,6 +978,22 @@ TEST_CASE("multiple file-descriptors sync", "[littlefs]")
     test_teardown();
 }
 
+#if CONFIG_LITTLEFS_SPIFFS_COMPAT
+TEST_CASE("SPIFFS COMPAT", "[littlefs]")
+{
+    test_setup();
+
+    const char* filename = littlefs_base_path "/foo/bar/spiffs_compat.bin";
+
+    FILE* f = fopen(filename, "w");
+    TEST_ASSERT_NOT_NULL(f);
+    TEST_ASSERT_TRUE(fputs("bar", f) != EOF);
+    TEST_ASSERT_EQUAL(0, fclose(f));
+
+    test_teardown();
+}
+#endif  // CONFIG_LITTLEFS_SPIFFS_COMPAT
+
 
 static void test_setup() {
     const esp_vfs_littlefs_conf_t conf = {


### PR DESCRIPTION
Adds the flag `CONFIG_LITTLEFS_SPIFFS_COMPAT` that allows littlefs to be more drop-in friendly to replace SPIFFS. Namely:

1. Create directories as needed when creating a file.
2. Delete directories as they become empty.

Both of these are artifacts of the fact that SPIFFS doesn't contain folders, and folders are considered part of a file name.

Addresses:
https://github.com/joltwallet/esp_littlefs/issues/14