### PR TITLE
Multi fd

### DIFF
--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -1115,6 +1115,9 @@ static ssize_t vfs_littlefs_pread(void *ctx, int fd, void *dst, size_t size, off
     /* Read the data.  */
     res = lfs_file_read(efs->fs, &file->file->file, dst, size);
 
+    // We don't have to reset the position since we manage that
+    // externally to lfs
+
     sem_give(efs);
 
 exit:

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -15,6 +15,19 @@ extern "C" {
 #endif
 
 /**
+ *  @brief additional metadata for a lfs_file_t.
+ *
+ *  We need this structure so that we can share a single lfs_file_t
+ *  among multiple file descriptors for the same file, since upstream
+ *  littlefs doesn't fully support multiple openings of the same file.
+ *
+ */
+typedef struct _vfs_littlefs_file_wrapper_t {
+    lfs_file_t file;
+    uint8_t open_count;  /*!< Number of times this file has been opened */
+} vfs_littlefs_file_wrapper_t;
+
+/**
  * @brief a file descriptor
  * That's also a singly linked list used for keeping tracks of all opened file descriptor 
  *
@@ -31,10 +44,9 @@ extern "C" {
  *    2. Same as (1), but for renames
  */
 typedef struct _vfs_littlefs_file_t {
-    lfs_file_t file;
+    vfs_littlefs_file_wrapper_t *file;
     uint32_t   hash;
     struct _vfs_littlefs_file_t * next;       /*!< Pointer to next file in Singly Linked List */
-    uint8_t open_count;  /*!< Number of times this file has been opened */
 #ifndef CONFIG_LITTLEFS_USE_ONLY_HASH
     char     * path;
 #endif

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -45,6 +45,7 @@ typedef struct _vfs_littlefs_file_wrapper_t {
  */
 typedef struct _vfs_littlefs_file_t {
     vfs_littlefs_file_wrapper_t *file;
+    lfs_off_t pos;  /*!< We externally store the file position so we can correctly handle multiple FD on a single file. */
     uint32_t   hash;
     struct _vfs_littlefs_file_t * next;       /*!< Pointer to next file in Singly Linked List */
 #ifndef CONFIG_LITTLEFS_USE_ONLY_HASH

--- a/src/test/test_littlefs.c
+++ b/src/test/test_littlefs.c
@@ -953,8 +953,8 @@ TEST_CASE("multiple file-descriptors sync", "[littlefs]")
 
     /* Run this test several times, there seems to be some non-determinism */
     for(int i=0; i < 10; i++) {
-        uint8_t buf1[1] = {'a'};
-        uint8_t buf2[1] = {};
+        char buf1[]= "bar";
+        char buf2[16];
 
         unlink(filename);
 
@@ -970,7 +970,13 @@ TEST_CASE("multiple file-descriptors sync", "[littlefs]")
 
         lseek(fd2, 0, SEEK_SET);
         read(fd2, &buf2, sizeof(buf2));
-        TEST_ASSERT_EQUAL_STRING_LEN(buf1, buf2, 1);
+        TEST_ASSERT_EQUAL_STRING(buf1, buf2);
+
+        /* fd2 pos should not influence fd1 pos */
+        lseek(fd2, 1, SEEK_SET);
+        TEST_ASSERT_EQUAL(3, lseek(fd1, 0, SEEK_CUR));
+        //read(fd1, &buf2, sizeof(buf2));
+        //TEST_ASSERT_EQUAL_STRING(buf1, buf2);
 
         close(fd1);
         close(fd2);

--- a/src/test/test_littlefs.c
+++ b/src/test/test_littlefs.c
@@ -974,9 +974,7 @@ TEST_CASE("multiple file-descriptors sync", "[littlefs]")
 
         /* fd2 pos should not influence fd1 pos */
         lseek(fd2, 1, SEEK_SET);
-        TEST_ASSERT_EQUAL(3, lseek(fd1, 0, SEEK_CUR));
-        //read(fd1, &buf2, sizeof(buf2));
-        //TEST_ASSERT_EQUAL_STRING(buf1, buf2);
+        TEST_ASSERT_EQUAL(sizeof(buf1), lseek(fd1, 0, SEEK_CUR));
 
         close(fd1);
         close(fd2);


### PR DESCRIPTION
Shares a common `lfs_file_t` among descriptors when opening a file. This fixes the previous PR where the exact same FD was returned. This was bad for two reasons:

1. Each FD should be unique (but it probably wouldn't impact 99% of people).
2. More importantly, the file position would be shared among the file descriptors, which is certainly not desired. We fixed this by keeping our own copy of where we are in a file.

NOTE: this solution has the following cons:
1. Uses up approximately 12 bytes of additional memory per file descriptor operating on unique files.
2. There **might** be some sort of cache thrashing when multiple descriptors operate on the same file. Specifically, when one is writing and the other is reading at the same time. This is because the writes have to be flushed to disk before moving position to read. This needs more real-life feedback.