### PR TITLE
Add upload to ESP component service workflow

### DIFF
--- a/.github/workflows/esp_upload_component.yml
+++ b/.github/workflows/esp_upload_component.yml
@@ -1,0 +1,18 @@
+name: Push LittleFS to Espressif Component Service
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Upload component to component service
+        uses: espressif/github-actions/upload_components@master
+        with:
+          name: "LittleFS"
+          namespace: "joltwallet"
+          api_token: ${{ secrets.ESP_IDF_COMPONENT_API_TOKEN }} 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 
-if (NOT DEFINED PROJECT_NAME)
-    include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-    project(esp_littlefs)
-else ()
-    file(GLOB SOURCES src/littlefs/*.c)
-    list(APPEND SOURCES src/esp_littlefs.c src/littlefs_api.c)
-    idf_component_register(
-        SRCS ${SOURCES}
-        INCLUDE_DIRS src include
-        REQUIRES spi_flash)
-endif (NOT DEFINED PROJECT_NAME)
+file(GLOB SOURCES src/littlefs/*.c)
+list(APPEND SOURCES src/esp_littlefs.c src/littlefs_api.c)
+idf_component_register(
+    SRCS ${SOURCES}
+    INCLUDE_DIRS src include
+    REQUIRES spi_flash)

--- a/README.md
+++ b/README.md
@@ -8,14 +8,23 @@ because SPIFFS was too slow, and FAT was too fragile.
 
 # How to Use
 
-In your project, add this as a submodule to your `components/` directory.
+There are two ways to add this component to your project
+
+1. As a ESP-IDF managed component: In your project directory run
+
+```
+idf.py add-dependency joltwallet/LittleFS==x.y.z
+```
+Where `x.y.z` is required version of this component, or:
+
+2. As a submodule: In your project, add this as a submodule to your `components/` directory.
 
 ```
 git submodule add https://github.com/joltwallet/esp_littlefs.git
 git submodule update --init --recursive
 ```
 
-The library can be configured via `make menuconfig` under `Component config->LittleFS`.
+The library can be configured via `idf.py menuconfig` under `Component config->LittleFS`.
 
 ### Example
 User @wreyford has kindly provided a demo repo showing the use of `esp_littlefs`:
@@ -23,7 +32,7 @@ https://github.com/wreyford/demo_esp_littlefs
 
 # Documentation
 
-See the official ESP-IDF SPIFFS documentation, basically all the functionality is the 
+See the official [ESP-IDF SPIFFS documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/storage/spiffs.html), basically all the functionality is the 
 same; just replace `spiffs` with `littlefs` in all function calls.
 
 Also see the comments in `include/esp_littlefs.h`

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,5 @@
+version: "1.0.0"
+description: LittleFS is a small fail-safe filesystem for micro-controllers.
+url: https://github.com/joltwallet/esp_littlefs
+dependencies:
+  idf: ">=4.1" 


### PR DESCRIPTION
### Description of the feature or fix
This PR adds a workflow for uploading to Espressif's component service. 

Idf-component-manager is a new function that allows ESP-IDF users to integrate software package into their project seamlessly.
More information about idf-component manager can be found in [Espressif API guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/tools/idf-component-manager.html) or [PyPi registry](https://pypi.org/project/idf-component-manager/). The component service itself is hosted [here](https://components.espressif.com/).

I can see that you don't use any versioning scheme, so the package is published on every push to `master` branch, but it can be changed to upload on successful release on GitHub, if you plan to use them.

Please also note that you need to bump component version in `idf_component.yml` before uploading it, otherwise the component service won't accept the new version.

Commit https://github.com/joltwallet/esp_littlefs/commit/cd33975e88a838832f2ef718d2966f0dd7515111 also removes project-wide Cmake configuration, as the project build have failed. I can revert it if you want to keep it that way.

In order to upload to Espressif's registry, an API token must be added to Github secrets (see [.github/workflows/esp_upload_component.yml  line 18](https://github.com/tore-espressif/esp_littlefs/blob/cd33975e88a838832f2ef718d2966f0dd7515111/.github/workflows/esp_upload_component.yml#L18)), I can send it to you in private message, if you agree.

Closes https://github.com/espressif/esp-idf/pull/5469

### Checkpoints
- [ ] Add ESP_IDF token to Github secrets