### PR TITLE
Support alternative IDF version syntax

### DIFF
--- a/project_include.cmake
+++ b/project_include.cmake
@@ -38,9 +38,12 @@ function(littlefs_create_partition_image partition base_dir)
 			ADDITIONAL_MAKE_CLEAN_FILES
 			${image_file})
 
-		string(SUBSTRING "${IDF_VER}" 1 -1 IDF_VER_NO_V)
+		if(IDF_VER MATCHES "^v")
+			string(SUBSTRING "${IDF_VER}" 1 -1 IDF_VER_NO_V)
+		else()
+			string(SUBSTRING "${IDF_VER}" 0 -1 IDF_VER_NO_V)
+		endif()
 
-		
 		if(${IDF_VER_NO_V} VERSION_LESS 4.1)
 			message(WARNING "Unsupported/unmaintained/deprecated ESP-IDF version ${IDF_VER}")
 		endif()


### PR DESCRIPTION
Currently using this as a ESP-IDF component, but making use of platformio. For some reason, ```IDF_VER``` does not start with a ```v```, resulting in an off by one error.