### PR TITLE
Add config to flush data at each write

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -133,5 +133,14 @@ menu "LittleFS"
             instead of throwing an error. Similarly, upon the deletion of the
             last file in a folder, the folder will be deleted. It is recommended
             to only enable this flag as a stop-gap solution.
+            
+    config LITTLEFS_FLUSH_FILE_EVERY_WRITE
+        bool "Flush file to flash after each write operation"
+        default "n"
+        help
+            Enabling this feature extends SPIFFS capability.
+            In SPIFFS data is written immediately to the flash storage when fflush() function called.
+            In LittleFS flush() does not write data to the flash, and fsync() call needed after.
+            With this feature fflush() will write data to the storage.
 
 endmenu

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -973,6 +973,11 @@ static ssize_t vfs_littlefs_write(void* ctx, int fd, const void * data, size_t s
     }
     file = efs->cache[fd];
     res = lfs_file_write(efs->fs, &file->file, data, size);
+#ifdef CONFIG_LITTLEFS_FLUSH_FILE_EVERY_WRITE
+    if(res > 0) {
+        res = vfs_littlefs_fsync(ctx, fd);
+    }
+#endif
     sem_give(efs);
 
     if(res < 0){


### PR DESCRIPTION
Fix for the problem described in #61 

In SPIFFS data is written immediately to the flash storage when fflush() function called.
In LittleFS flush() does not write data to the flash, and fsync() call needed after.
With this feature fflush() will write data to the storage.