### PR TITLE
Fix build issues with latest ESP-IDF master branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ list(APPEND SOURCES src/esp_littlefs.c src/littlefs_api.c src/lfs_config.c)
 idf_component_register(
     SRCS ${SOURCES}
     INCLUDE_DIRS src include
-    REQUIRES spi_flash
+    REQUIRES spi_flash vfs
     PRIV_REQUIRES esptool_py
     )
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "1.3.1"
+version: "1.3.1~1"
 description: LittleFS is a small fail-safe filesystem for micro-controllers.
 url: https://github.com/joltwallet/esp_littlefs
 dependencies:


### PR DESCRIPTION
- Add explicit dependency for `vfs` component
- Bump up component revision

Closes https://github.com/joltwallet/esp_littlefs/issues/86
