### PR TITLE
Add mutex to utime for thread safety.

### DIFF
--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -1787,6 +1787,7 @@ static int vfs_littlefs_utime(void *ctx, const char *path, const struct utimbuf 
 
     assert(path);
 
+    sem_take(efs);
     if (times) {
         t = times->modtime;
     } else {
@@ -1806,6 +1807,7 @@ static int vfs_littlefs_utime(void *ctx, const char *path, const struct utimbuf 
     }
 
     int ret = vfs_littlefs_update_mtime_value(efs, path, t);
+    sem_give(efs);
     return ret;
 }
 


### PR DESCRIPTION
I encountered filesystem errors and sometimes crashes when attempting to call `utime` and `fsync` at the same time. Adding the mutex to `utime` resolves the issue.

Unfortunately, I'm not able to get your unit tests to run, nor am I sure where to add a test for this specific case. This does seem to be related to #7 