### PR TITLE
Fix LITTLEFS_USE_ONLY_HASH=y with recent esp-idf

### DIFF
--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -1771,7 +1771,11 @@ static int vfs_littlefs_ftruncate(void *ctx, int fd, off_t size)
     }
     else
     {
+#ifndef CONFIG_LITTLEFS_USE_ONLY_HASH
         ESP_LOGV( TAG, "Truncated file %s to %u bytes", file->path, (unsigned int) size );
+#else
+        ESP_LOGV(TAG, "Truncated FD %d to %u bytes", fd, (unsigned int) size );
+#endif
     }
     return res;
 


### PR DESCRIPTION
Currently, having CONFIG_LITTLEGS_USE_ONLY_HASH set to `y` breaks the build when using esp-idf >= v4.4.2.