### PR TITLE
fix: default log level was set to max

### DIFF
--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -4,7 +4,9 @@
  * @author Brian Pugh
  */
 
-//#define LOG_LOCAL_LEVEL 5
+#ifndef LOG_LOCAL_LEVEL
+#define LOG_LOCAL_LEVEL CONFIG_LOG_DEFAULT_LEVEL
+#endif // LOG_LOCAL_LEVEL
 
 #include "esp_littlefs.h"
 #include "esp_log.h"


### PR DESCRIPTION
If the default level and maximum level are not the same, littlfs uses LOG_LOCAL_LEVEL as LOG_MAXIMUM_LEVEL which causes issues.
