### PR TITLE
Update LittleFS to v2.8.0; introduce grow_on_mount.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Slight differences between this configuration and SPIFFS's configuration is in t
 
 1. `max_files` field doesn't exist since we removed the file limit, thanks to @X-Ryl669
 2. `partition_label` is not allowed to be `NULL`. You must specify the partition name from your partition table. This is because there isn't a define `littlefs` partition subtype in `esp-idf`. The subtype doesn't matter.
+    * Alternatively, you can specify an `esp_partition_t*` to a `partition` and set `partition_label=NULL`.
+3. `grow_on_mount` will expand an existing filesystem to fill the partition. Defaults to `false`.
+    * LittleFS filesystems can only grow, they cannot shrink.
 
 ### Filesystem Image Creation
 

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -28,11 +28,12 @@ typedef struct {
     const esp_partition_t* partition; /**< partition to use if partition_label is NULL */
     uint8_t format_if_mount_failed:1; /**< Format the file system if it fails to mount. */
     uint8_t read_only : 1;            /**< Mount the partition as read-only. */
-    uint8_t dont_mount:1;             /**< Don't attempt to mount or format. Overrides format_if_mount_failed */
+    uint8_t dont_mount:1;             /**< Don't attempt to mount.*/
+    uint8_t grow_on_mount:1;          /**< Grow filesystem to match partition size on mount.*/
 } esp_vfs_littlefs_conf_t;
 
 /**
- * Register and mount littlefs to VFS with given path prefix.
+ * Register and mount (if configured to) littlefs to VFS with given path prefix.
  *
  * @param   conf                      Pointer to esp_vfs_littlefs_conf_t configuration structure
  *


### PR DESCRIPTION
Addresses #145 . This introduces the `grow_on_mount` flag to `esp_vfs_littlefs_conf_t`. Note that filesystems can only be grown by adding more space to the end of the partition, you cannot move the partition's starting offset.

Additionally, filesystem sizes (`block_count`) are now autodetected instead of assuming to take up the entire provided partition.

@Jason2866 @s-hadinger, please give this a test and let me know if that satisfies your use case.