### PR TITLE
Add CFLAG to select SPIRAM heap caps malloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,3 +34,7 @@ endif()
 if(CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE)
     target_compile_definitions(${COMPONENT_LIB} PUBLIC -DLFS_NO_MALLOC)
 endif()
+
+if(NOT CONFIG_LITTLEFS_ASSERTS)
+    target_compile_definitions(${COMPONENT_LIB} PUBLIC -DLFS_NO_ASSERT)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,3 +30,7 @@ endif()
 if(CONFIG_LITTLEFS_MULTIVERSION)
     target_compile_definitions(${COMPONENT_LIB} PUBLIC -DLFS_MULTIVERSION)
 endif()
+
+if(CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE)
+    target_compile_definitions(${COMPONENT_LIB} PUBLIC -DLFS_NO_MALLOC)
+endif()

--- a/Kconfig
+++ b/Kconfig
@@ -238,5 +238,12 @@ menu "LittleFS"
             help
                 Uses ESP-IDF heap_caps_malloc to prefer allocation from SPIRAM heap.
 
-    endchoice    
+    endchoice
+
+    config LITTLEFS_ASSERTS
+        bool "Enable asserts"
+        default "y"
+        help
+            Selects whether littlefs performs runtime assert checks.
+
 endmenu

--- a/Kconfig
+++ b/Kconfig
@@ -227,12 +227,12 @@ menu "LittleFS"
                 On systems with heap in PSRAM, if the allocation size exceeds SPIRAM_MALLOC_ALWAYSINTERNAL
                 then external heap will be preferred.
 
-        config LITTLEFS_MALLOC_STRATEGY_INTERNAL_ONLY
+        config LITTLEFS_MALLOC_STRATEGY_INTERNAL
             bool "Internal heap"
             help
                 Uses ESP-IDF heap_caps_malloc to prefer allocation from internal heap.
 
-        config LITTLEFS_MALLOC_STRATEGY_SPIRAM_ONLY
+        config LITTLEFS_MALLOC_STRATEGY_SPIRAM
             bool "SPIRAM heap"
             depends on SPIRAM_USE_MALLOC && ESP32_SPIRAM_SUPPORT
             help

--- a/Kconfig
+++ b/Kconfig
@@ -208,4 +208,35 @@ menu "LittleFS"
             bool "Write LittleFS 2.0 (no forward-looking erase-state CRCs)"
 
     endchoice
+
+    choice LITTLEFS_MALLOC_STRATEGY
+        prompt "Buffer allocation strategy"
+        default LITTLEFS_MALLOC_STRATEGY_GENERAL
+        help
+            Maps lfs_malloc to ESP-IDF capabilities-based memory allocator or
+            disables dynamic allocation in favour of user-provided static buffers.
+
+        config LITTLEFS_MALLOC_STRATEGY_DISABLE
+            bool "Static buffers only"
+            help
+                Disallow dynamic allocation, static buffers must be provided by the calling application.
+
+        config LITTLEFS_MALLOC_STRATEGY_GENERAL
+            bool "System malloc"
+            help
+                On systems with heap in PSRAM, if the allocation size exceeds SPIRAM_MALLOC_ALWAYSINTERNAL
+                then external heap will be preferred.
+
+        config LITTLEFS_MALLOC_STRATEGY_INTERNAL_ONLY
+            bool "Internal heap"
+            help
+                Uses ESP-IDF heap_caps_malloc to prefer allocation from internal heap.
+
+        config LITTLEFS_MALLOC_STRATEGY_SPIRAM_ONLY
+            bool "SPIRAM heap"
+            depends on SPIRAM_USE_MALLOC && ESP32_SPIRAM_SUPPORT
+            help
+                Uses ESP-IDF heap_caps_malloc to prefer allocation from SPIRAM heap.
+
+    endchoice    
 endmenu

--- a/Kconfig
+++ b/Kconfig
@@ -211,7 +211,7 @@ menu "LittleFS"
 
     choice LITTLEFS_MALLOC_STRATEGY
         prompt "Buffer allocation strategy"
-        default LITTLEFS_MALLOC_STRATEGY_GENERAL
+        default LITTLEFS_MALLOC_STRATEGY_DEFAULT
         help
             Maps lfs_malloc to ESP-IDF capabilities-based memory allocator or
             disables dynamic allocation in favour of user-provided static buffers.
@@ -221,22 +221,24 @@ menu "LittleFS"
             help
                 Disallow dynamic allocation, static buffers must be provided by the calling application.
 
-        config LITTLEFS_MALLOC_STRATEGY_GENERAL
-            bool "System malloc"
+        config LITTLEFS_MALLOC_STRATEGY_DEFAULT
+            bool "Default heap selection"
             help
-                On systems with heap in PSRAM, if the allocation size exceeds SPIRAM_MALLOC_ALWAYSINTERNAL
-                then external heap will be preferred.
+                Uses an automatic allocation strategy. On systems with heap in SPIRAM, if
+                the allocation size does not exceed SPIRAM_MALLOC_ALWAYSINTERNAL then internal
+                heap allocation if preferred, otherwise allocation will be attempted from SPIRAM
+                heap.
 
         config LITTLEFS_MALLOC_STRATEGY_INTERNAL
             bool "Internal heap"
             help
-                Uses ESP-IDF heap_caps_malloc to prefer allocation from internal heap.
+                Uses ESP-IDF heap_caps_malloc to allocate from internal heap.
 
         config LITTLEFS_MALLOC_STRATEGY_SPIRAM
             bool "SPIRAM heap"
             depends on SPIRAM_USE_MALLOC && ESP32_SPIRAM_SUPPORT
             help
-                Uses ESP-IDF heap_caps_malloc to prefer allocation from SPIRAM heap.
+                Uses ESP-IDF heap_caps_malloc to allocate from SPIRAM heap.
 
     endchoice
 

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -162,9 +162,9 @@ static const char * esp_littlefs_errno(enum lfs_error lfs_errno);
 
 static inline void * esp_littlefs_calloc(size_t __nmemb, size_t __size) {
     /* Used internally by this wrapper only */
-#if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL_ONLY)
+#if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL)
     return heap_caps_calloc(__nmemb, __size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
-#elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM_ONLY)
+#elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
     return heap_caps_calloc(__nmemb, __size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
 #else /* CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE, CONFIG_LITTLEFS_MALLOC_STRATEGY_GENERAL and default */
     return calloc(__nmemb, __size);

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -166,7 +166,7 @@ static inline void * esp_littlefs_calloc(size_t __nmemb, size_t __size) {
     return heap_caps_calloc(__nmemb, __size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
 #elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
     return heap_caps_calloc(__nmemb, __size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
-#else /* CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE, CONFIG_LITTLEFS_MALLOC_STRATEGY_DEFAULT and default */
+#else /* CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE, CONFIG_LITTLEFS_MALLOC_STRATEGY_DEFAULT or not defined */
     return calloc(__nmemb, __size);
 #endif
 }
@@ -1170,7 +1170,7 @@ static int vfs_littlefs_open(void* ctx, const char * path, int flags, int mode) 
     /* Open File */
     res = lfs_file_open(efs->fs, &file->file, path, lfs_flags);
 #else
-    #error "The use of static buffers is not current supported by this VFS wrapper"
+    #error "The use of static buffers is not currently supported by this VFS wrapper"
 #endif
 
 #if CONFIG_LITTLEFS_OPEN_DIR

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -166,7 +166,7 @@ static inline void * esp_littlefs_calloc(size_t __nmemb, size_t __size) {
     return heap_caps_calloc(__nmemb, __size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
 #elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
     return heap_caps_calloc(__nmemb, __size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
-#else /* CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE, CONFIG_LITTLEFS_MALLOC_STRATEGY_GENERAL and default */
+#else /* CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE, CONFIG_LITTLEFS_MALLOC_STRATEGY_DEFAULT and default */
     return calloc(__nmemb, __size);
 #endif
 }

--- a/src/lfs_config.h
+++ b/src/lfs_config.h
@@ -215,7 +215,6 @@ static inline void *lfs_malloc(size_t size) {
 #else
     return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
 #endif
-
 #else
     (void)size;
     return NULL;

--- a/src/lfs_config.h
+++ b/src/lfs_config.h
@@ -210,7 +210,12 @@ uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);
 // Note, memory must be 64-bit aligned
 static inline void *lfs_malloc(size_t size) {
 #ifndef LFS_NO_MALLOC
+#ifdef LFS_MALLOC_SPIRAM
+    return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
+#else
     return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
+#endif
+
 #else
     (void)size;
     return NULL;

--- a/src/lfs_config.h
+++ b/src/lfs_config.h
@@ -23,7 +23,7 @@
 #include "esp_heap_caps.h"
 #endif
 
-#ifndef LFS_NO_ASSERT
+#ifdef CONFIG_LITTLEFS_ASSERTS
 #include <assert.h>
 #endif
 
@@ -87,12 +87,10 @@ extern const char ESP_LITTLEFS_TAG[];
 #endif
 
 // Runtime assertions
-#ifndef LFS_ASSERT
-#ifndef LFS_NO_ASSERT
+#ifdef CONFIG_LITTLEFS_ASSERTS
 #define LFS_ASSERT(test) assert(test)
 #else
 #define LFS_ASSERT(test)
-#endif
 #endif
 
 

--- a/src/lfs_config.h
+++ b/src/lfs_config.h
@@ -231,7 +231,7 @@ static inline void lfs_free(void *p) {
     defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL) || \
     defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
     free(p);
-#else // CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE and default
+#else // CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE or not defined
     (void)p;
 #endif
 }

--- a/src/lfs_config.h
+++ b/src/lfs_config.h
@@ -17,8 +17,8 @@
 
 
 #if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_GENERAL) || \
-    defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL_ONLY) || \
-    defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM_ONLY)
+    defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL) || \
+    defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
 #include <stdlib.h>
 #include "esp_heap_caps.h"
 #endif
@@ -217,9 +217,9 @@ uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);
 static inline void *lfs_malloc(size_t size) {
 #if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_GENERAL)
     return malloc(size);
-#elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL_ONLY)
+#elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL)
     return heap_caps_aligned_alloc(8, size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
-#elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM_ONLY)
+#elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
     return heap_caps_aligned_alloc(8, size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
 #else // CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE and default
     (void)size;
@@ -230,8 +230,8 @@ static inline void *lfs_malloc(size_t size) {
 // Deallocate memory, only used if buffers are not provided to littlefs
 static inline void lfs_free(void *p) {
 #if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_GENERAL) || \
-    defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL_ONLY) || \
-    defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM_ONLY)
+    defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL) || \
+    defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
     free(p);
 #else // CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE and default
     (void)p;

--- a/src/lfs_config.h
+++ b/src/lfs_config.h
@@ -16,7 +16,7 @@
 #include "esp_log.h"
 
 
-#if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_GENERAL) || \
+#if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_DEFAULT) || \
     defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL) || \
     defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
 #include <stdlib.h>
@@ -211,14 +211,14 @@ static inline uint32_t lfs_tobe32(uint32_t a) {
 uint32_t lfs_crc(uint32_t crc, const void *buffer, size_t size);
 
 // Allocate memory, only used if buffers are not provided to littlefs
-// Note, memory must be 64-bit aligned
+// For the lookahead buffer, memory must be 32-bit aligned
 static inline void *lfs_malloc(size_t size) {
-#if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_GENERAL)
-    return malloc(size);
+#if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_DEFAULT)
+    return malloc(size); // Equivalent to heap_caps_malloc_default(size);
 #elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL)
-    return heap_caps_aligned_alloc(8, size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
+    return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
 #elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
-    return heap_caps_aligned_alloc(8, size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
+    return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
 #else // CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE and default
     (void)size;
     return NULL;
@@ -227,7 +227,7 @@ static inline void *lfs_malloc(size_t size) {
 
 // Deallocate memory, only used if buffers are not provided to littlefs
 static inline void lfs_free(void *p) {
-#if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_GENERAL) || \
+#if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_DEFAULT) || \
     defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL) || \
     defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
     free(p);

--- a/src/lfs_config.h
+++ b/src/lfs_config.h
@@ -219,7 +219,7 @@ static inline void *lfs_malloc(size_t size) {
     return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
 #elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
     return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
-#else // CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE and default
+#else // CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE or not defined
     (void)size;
     return NULL;
 #endif


### PR DESCRIPTION
Allows including project to select SPIRAM for mallocs with `add_compile_definitions(LFS_MALLOC_SPIRAM)`