### PR TITLE
SD card (sdmmc driver) support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,22 @@
 cmake_minimum_required(VERSION 3.10)
 
 file(GLOB SOURCES src/littlefs/*.c)
-list(APPEND SOURCES src/esp_littlefs.c src/littlefs_esp_part.c src/littlefs_sdmmc.c src/lfs_config.c)
+list(APPEND SOURCES src/esp_littlefs.c src/littlefs_esp_part.c src/lfs_config.c)
+
+if(CONFIG_LITTLEFS_SDMMC_SUPPORT)
+    list(APPEND SOURCES src/littlefs_sdmmc.c)
+endif()
 
 if(IDF_VERSION_MAJOR GREATER_EQUAL 5)
-    list(APPEND pub_requires esp_partition sdmmc)
+    if (CONFIG_LITTLEFS_SDMMC_SUPPORT)
+        list(APPEND pub_requires esp_partition sdmmc)
+    else()
+        list(APPEND pub_requires esp_partition sdmmc)
+    endif()
 else()
     list(APPEND pub_requires spi_flash)
 endif()
-list(APPEND priv_requires esptool_py spi_flash vfs sdmmc)
+list(APPEND priv_requires esptool_py spi_flash vfs)
 
 idf_component_register(
     SRCS ${SOURCES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,14 @@
 cmake_minimum_required(VERSION 3.10)
 
 file(GLOB SOURCES src/littlefs/*.c)
-list(APPEND SOURCES src/esp_littlefs.c src/littlefs_api.c src/lfs_config.c)
+list(APPEND SOURCES src/esp_littlefs.c src/littlefs_esp_part.c src/littlefs_sdmmc.c src/lfs_config.c)
 
 if(IDF_VERSION_MAJOR GREATER_EQUAL 5)
-    list(APPEND pub_requires esp_partition)
+    list(APPEND pub_requires esp_partition sdmmc)
 else()
     list(APPEND pub_requires spi_flash)
 endif()
-list(APPEND priv_requires esptool_py spi_flash vfs)
+list(APPEND priv_requires esptool_py spi_flash vfs sdmmc)
 
 idf_component_register(
     SRCS ${SOURCES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,15 +8,11 @@ if(CONFIG_LITTLEFS_SDMMC_SUPPORT)
 endif()
 
 if(IDF_VERSION_MAJOR GREATER_EQUAL 5)
-    if (CONFIG_LITTLEFS_SDMMC_SUPPORT)
-        list(APPEND pub_requires esp_partition sdmmc)
-    else()
-        list(APPEND pub_requires esp_partition sdmmc)
-    endif()
+    list(APPEND pub_requires esp_partition)
 else()
     list(APPEND pub_requires spi_flash)
 endif()
-list(APPEND priv_requires esptool_py spi_flash vfs)
+list(APPEND priv_requires esptool_py spi_flash vfs sdmmc)
 
 idf_component_register(
     SRCS ${SOURCES}

--- a/Kconfig
+++ b/Kconfig
@@ -1,5 +1,12 @@
 menu "LittleFS"
 
+    config LITTLEFS_SDMMC_SUPPORT
+        bool "SDMMC support (requires ESP-IDF v5+)"
+        default n
+        help
+            Toggle SD card support
+            This requires IDF v5+ as older ESP-IDF do not support SD card erase.
+
     config LITTLEFS_MAX_PARTITIONS
         int "Maximum Number of Partitions"
         default 3

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -70,7 +70,7 @@ esp_err_t esp_vfs_littlefs_unregister(const char* partition_label);
 /**
  * Unregister and unmount LittleFS from VFS for SD card
  *
- * @param partition_label  Label of the partition to unregister.
+ * @param sdcard  SD card to unregister.
  *
  * @return
  *          - ESP_OK if successful
@@ -136,7 +136,7 @@ esp_err_t esp_littlefs_format_partition(const esp_partition_t* partition);
 /**
  * Format the LittleFS on a SD card
  *
- * @param partition  partition to format.
+ * @param sdcard SD card to format
  * @return
  *          - ESP_OK      if successful
  *          - ESP_FAIL    on error
@@ -169,6 +169,21 @@ esp_err_t esp_littlefs_info(const char* partition_label, size_t* total_bytes, si
  *          - ESP_ERR_INVALID_STATE   if not mounted
  */
 esp_err_t esp_littlefs_partition_info(const esp_partition_t* partition, size_t *total_bytes, size_t *used_bytes);
+
+#ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
+/**
+ * Get information for littlefs on SD card
+ *
+ * @param[in] sdcard                    the SD card to get info for.
+ * @param[out] total_bytes          Size of the file system
+ * @param[out] used_bytes           Current used bytes in the file system
+ *
+ * @return
+ *          - ESP_OK                  if success
+ *          - ESP_ERR_INVALID_STATE   if not mounted
+ */
+esp_err_t esp_littlefs_sdmmc_info(sdmmc_card_t *sdcard, size_t *total_bytes, size_t *used_bytes);
+#endif
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -4,8 +4,11 @@
 #include "esp_err.h"
 #include "esp_idf_version.h"
 #include <stdbool.h>
-#include <sdmmc_cmd.h>
 #include "esp_partition.h"
+
+#ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
+#include <sdmmc_cmd.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -27,7 +30,11 @@ typedef struct {
     const char *base_path;            /**< Mounting point. */
     const char *partition_label;      /**< Label of partition to use. */
     const esp_partition_t* partition; /**< partition to use if partition_label is NULL */
+
+#ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
     sdmmc_card_t *sdcard;       /**< SD card handle to use if both esp_partition handle & partition label is NULL */
+#endif
+
     uint8_t format_if_mount_failed:1; /**< Format the file system if it fails to mount. */
     uint8_t read_only : 1;            /**< Mount the partition as read-only. */
     uint8_t dont_mount:1;             /**< Don't attempt to mount.*/

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -66,6 +66,19 @@ esp_err_t esp_vfs_littlefs_register(const esp_vfs_littlefs_conf_t * conf);
  */
 esp_err_t esp_vfs_littlefs_unregister(const char* partition_label);
 
+#ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
+/**
+ * Unregister and unmount LittleFS from VFS for SD card
+ *
+ * @param partition_label  Label of the partition to unregister.
+ *
+ * @return
+ *          - ESP_OK if successful
+ *          - ESP_ERR_INVALID_STATE already unregistered
+ */
+esp_err_t esp_vfs_littlefs_unregister_sdmmc(sdmmc_card_t *sdcard);
+#endif
+
 /**
  * Unregister and unmount littlefs from VFS
  *
@@ -118,6 +131,18 @@ esp_err_t esp_littlefs_format(const char* partition_label);
  *          - ESP_FAIL    on error
  */
 esp_err_t esp_littlefs_format_partition(const esp_partition_t* partition);
+
+#ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
+/**
+ * Format the LittleFS on a SD card
+ *
+ * @param partition  partition to format.
+ * @return
+ *          - ESP_OK      if successful
+ *          - ESP_FAIL    on error
+ */
+esp_err_t esp_littlefs_format_sdmmc(sdmmc_card_t *sdcard);
+#endif
 
 /**
  * Get information for littlefs

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -112,6 +112,19 @@ bool esp_littlefs_mounted(const char* partition_label);
  */
 bool esp_littlefs_partition_mounted(const esp_partition_t* partition);
 
+#ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
+/**
+ * Check if littlefs is mounted
+ *
+ * @param sdcard  SD card to check.
+ *
+ * @return
+ *          - true    if mounted
+ *          - false   if not mounted
+ */
+bool esp_littlefs_sdmmc_mounted(sdmmc_card_t *sdcard);
+#endif
+
 /**
  * Format the littlefs partition
  *

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -4,7 +4,7 @@
 #include "esp_err.h"
 #include "esp_idf_version.h"
 #include <stdbool.h>
-#include <driver/sdmmc_types.h>
+#include <sdmmc_cmd.h>
 #include "esp_partition.h"
 
 #ifdef __cplusplus

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -4,6 +4,7 @@
 #include "esp_err.h"
 #include "esp_idf_version.h"
 #include <stdbool.h>
+#include <driver/sdmmc_types.h>
 #include "esp_partition.h"
 
 #ifdef __cplusplus
@@ -26,6 +27,7 @@ typedef struct {
     const char *base_path;            /**< Mounting point. */
     const char *partition_label;      /**< Label of partition to use. */
     const esp_partition_t* partition; /**< partition to use if partition_label is NULL */
+    sdmmc_card_t *sdcard;       /**< SD card handle to use if both esp_partition handle & partition label is NULL */
     uint8_t format_if_mount_failed:1; /**< Format the file system if it fails to mount. */
     uint8_t read_only : 1;            /**< Mount the partition as read-only. */
     uint8_t dont_mount:1;             /**< Don't attempt to mount.*/

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -118,7 +118,10 @@ static esp_err_t esp_littlefs_init(const esp_vfs_littlefs_conf_t* conf);
 
 static esp_err_t esp_littlefs_by_label(const char* label, int * index);
 static esp_err_t esp_littlefs_by_partition(const esp_partition_t* part, int*index);
+
+#ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
 static esp_err_t esp_littlefs_by_sdmmc_handle(sdmmc_card_t *handle, int *index);
+#endif
 
 static esp_err_t esp_littlefs_get_empty(int *index);
 static void      esp_littlefs_free(esp_littlefs_t ** efs);

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -320,6 +320,17 @@ bool esp_littlefs_partition_mounted(const esp_partition_t* partition) {
     return _efs[index]->cache_size > 0;
 }
 
+#ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
+bool esp_littlefs_sdmmc_mounted(sdmmc_card_t *sdcard)
+{
+    int index;
+    esp_err_t err = esp_littlefs_by_sdmmc_handle(sdcard, &index);
+
+    if(err != ESP_OK) return false;
+    return _efs[index]->cache_size > 0;
+}
+#endif
+
 esp_err_t esp_littlefs_info(const char* partition_label, size_t *total_bytes, size_t *used_bytes){
     int index;
     esp_err_t err;
@@ -342,6 +353,7 @@ esp_err_t esp_littlefs_partition_info(const esp_partition_t* partition, size_t *
     return ESP_OK;
 }
 
+#ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
 esp_err_t esp_littlefs_sdmmc_info(sdmmc_card_t *sdcard, size_t *total_bytes, size_t *used_bytes)
 {
     int index;
@@ -353,6 +365,7 @@ esp_err_t esp_littlefs_sdmmc_info(sdmmc_card_t *sdcard, size_t *total_bytes, siz
 
     return ESP_OK;
 }
+#endif
 
 esp_err_t esp_vfs_littlefs_register(const esp_vfs_littlefs_conf_t * conf)
 {

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -226,6 +226,19 @@ esp_err_t format_from_efs(esp_littlefs_t *efs)
         esp_littlefs_free_fds(efs);
     }
 
+#ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
+    /* Format the SD card too */
+    if (efs->sdcard) {
+        esp_err_t ret = sdmmc_full_erase(efs->sdcard);
+        if (ret != ESP_OK) {
+            ESP_LOGE(ESP_LITTLEFS_TAG, "Failed to format SD card: 0x%x %s", ret, esp_err_to_name(ret));
+            return ret;
+        }
+
+        ESP_LOGI(ESP_LITTLEFS_TAG, "SD card formatted!");
+    }
+#endif
+
     /* Format */
     {
         int res;

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -749,25 +749,23 @@ static esp_err_t esp_littlefs_by_label(const char* label, int * index){
 #ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
 static esp_err_t esp_littlefs_by_sdmmc_handle(sdmmc_card_t *handle, int *index)
 {
-    int i;
-    esp_littlefs_t * p;
-
     if(!handle || !index) return ESP_ERR_INVALID_ARG;
 
     ESP_LOGV(ESP_LITTLEFS_TAG, "Searching for existing filesystem for SD handle %p", handle);
 
-    for (i = 0; i < CONFIG_LITTLEFS_MAX_PARTITIONS; i++) {
-        p = _efs[i];
-        if (p && p->sdcard) {
+    for (int i = 0; i < CONFIG_LITTLEFS_MAX_PARTITIONS; i++) {
+        esp_littlefs_t *p = _efs[i];
+        if (!p) continue;
+        if (p->sdcard) {
             if (p->sdcard == handle) {
                 *index = i;
-                ESP_LOGV(ESP_LITTLEFS_TAG, "Found existing filesystem %p at index %d", p->sdcard, *index);
+                ESP_LOGV(ESP_LITTLEFS_TAG, "Found existing filesystem %p at index %d", handle, *index);
                 return ESP_OK;
             }
         }
     }
 
-    ESP_LOGV(ESP_LITTLEFS_TAG, "Existing filesystem %p not found", p->sdcard);
+    ESP_LOGV(ESP_LITTLEFS_TAG, "Existing filesystem %p not found", handle);
     return ESP_ERR_NOT_FOUND;
 }
 #endif

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -342,6 +342,18 @@ esp_err_t esp_littlefs_partition_info(const esp_partition_t* partition, size_t *
     return ESP_OK;
 }
 
+esp_err_t esp_littlefs_sdmmc_info(sdmmc_card_t *sdcard, size_t *total_bytes, size_t *used_bytes)
+{
+    int index;
+    esp_err_t err;
+
+    err = esp_littlefs_by_sdmmc_handle(sdcard, &index);
+    if(err != ESP_OK) return err;
+    get_total_and_used_bytes(_efs[index], total_bytes, used_bytes);
+
+    return ESP_OK;
+}
+
 esp_err_t esp_vfs_littlefs_register(const esp_vfs_littlefs_conf_t * conf)
 {
     assert(conf->base_path);

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -719,7 +719,7 @@ static esp_err_t esp_littlefs_init_sdcard(esp_littlefs_t** efs, sdmmc_card_t* sd
         (*efs)->cfg.prog_size = sdcard->csd.sector_size;
         (*efs)->cfg.block_size = sdcard->csd.sector_size;
         (*efs)->cfg.block_count = sdcard->csd.capacity;
-        (*efs)->cfg.cache_size = CONFIG_LITTLEFS_CACHE_SIZE;
+        (*efs)->cfg.cache_size = MAX(CONFIG_LITTLEFS_CACHE_SIZE, sdcard->csd.sector_size); // Must not be smaller than SD sector size
         (*efs)->cfg.lookahead_size = CONFIG_LITTLEFS_LOOKAHEAD_SIZE;
         (*efs)->cfg.block_cycles = CONFIG_LITTLEFS_BLOCK_CYCLES;
 #if CONFIG_LITTLEFS_MULTIVERSION

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -9,7 +9,11 @@
 #include "esp_vfs.h"
 #include "esp_partition.h"
 #include "littlefs/lfs.h"
+#include <sdkconfig.h>
+
+#ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
 #include <sdmmc_cmd.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -46,7 +50,11 @@ typedef struct _vfs_littlefs_file_t {
 typedef struct {
     lfs_t *fs;                                /*!< Handle to the underlying littlefs */
     SemaphoreHandle_t lock;                   /*!< FS lock */
+
+#ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
     sdmmc_card_t *sdcard;                     /*!< The SD card driver handle on which littlefs is located */
+#endif
+
     const esp_partition_t* partition;         /*!< The partition on which littlefs is located */
     char base_path[ESP_VFS_PATH_MAX+1];       /*!< Mount point */
 
@@ -102,6 +110,8 @@ int littlefs_esp_part_erase(const struct lfs_config *c, lfs_block_t block);
  */
 int littlefs_esp_part_sync(const struct lfs_config *c);
 
+#ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
+
 /**
  * @brief Read a region in a block on SD card
  *
@@ -143,6 +153,8 @@ int littlefs_sdmmc_erase(const struct lfs_config *c, lfs_block_t block);
  * @return errorcode. 0 on success.
  */
 int littlefs_sdmmc_sync(const struct lfs_config *c);
+
+#endif // CONFIG_LITTLEFS_SDMMC_SUPPORT
 
 #ifdef __cplusplus
 }

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -9,6 +9,7 @@
 #include "esp_vfs.h"
 #include "esp_partition.h"
 #include "littlefs/lfs.h"
+#include <driver/sdmmc_types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,6 +46,7 @@ typedef struct _vfs_littlefs_file_t {
 typedef struct {
     lfs_t *fs;                                /*!< Handle to the underlying littlefs */
     SemaphoreHandle_t lock;                   /*!< FS lock */
+    sdmmc_card_t *sdcard;                     /*!< The SD card driver handle on which littlefs is located */
     const esp_partition_t* partition;         /*!< The partition on which littlefs is located */
     char base_path[ESP_VFS_PATH_MAX+1];       /*!< Mount point */
 
@@ -65,8 +67,8 @@ typedef struct {
  *
  * @return errorcode. 0 on success.
  */
-int littlefs_api_read(const struct lfs_config *c, lfs_block_t block,
-        lfs_off_t off, void *buffer, lfs_size_t size);
+int littlefs_esp_part_read(const struct lfs_config *c, lfs_block_t block,
+                           lfs_off_t off, void *buffer, lfs_size_t size);
 
 /**
  * @brief Program a region in a block.
@@ -77,8 +79,8 @@ int littlefs_api_read(const struct lfs_config *c, lfs_block_t block,
  *
  * @return errorcode. 0 on success.
  */
-int littlefs_api_prog(const struct lfs_config *c, lfs_block_t block,
-        lfs_off_t off, const void *buffer, lfs_size_t size);
+int littlefs_esp_part_write(const struct lfs_config *c, lfs_block_t block,
+                            lfs_off_t off, const void *buffer, lfs_size_t size);
 
 /**
  * @brief Erase a block.
@@ -89,7 +91,7 @@ int littlefs_api_prog(const struct lfs_config *c, lfs_block_t block,
  * May return LFS_ERR_CORRUPT if the block should be considered bad.
  * @return errorcode. 0 on success.
  */
-int littlefs_api_erase(const struct lfs_config *c, lfs_block_t block);
+int littlefs_esp_part_erase(const struct lfs_config *c, lfs_block_t block);
 
 /**
  * @brief Sync the state of the underlying block device.
@@ -98,7 +100,49 @@ int littlefs_api_erase(const struct lfs_config *c, lfs_block_t block);
  *
  * @return errorcode. 0 on success.
  */
-int littlefs_api_sync(const struct lfs_config *c);
+int littlefs_esp_part_sync(const struct lfs_config *c);
+
+/**
+ * @brief Read a region in a block on SD card
+ *
+ * Negative error codes are propogated to the user.
+ *
+ * @return errorcode. 0 on success.
+ */
+int littlefs_sdmmc_read(const struct lfs_config *c, lfs_block_t block,
+                           lfs_off_t off, void *buffer, lfs_size_t size);
+
+/**
+ * @brief Program a region in a block on SD card.
+ *
+ * The block must have previously been erased.
+ * Negative error codes are propogated to the user.
+ * May return LFS_ERR_CORRUPT if the block should be considered bad.
+ *
+ * @return errorcode. 0 on success.
+ */
+int littlefs_sdmmc_write(const struct lfs_config *c, lfs_block_t block,
+                            lfs_off_t off, const void *buffer, lfs_size_t size);
+
+/**
+ * @brief Erase a block on SD card.
+ *
+ * A block must be erased before being programmed.
+ * The state of an erased block is undefined.
+ * Negative error codes are propogated to the user.
+ * May return LFS_ERR_CORRUPT if the block should be considered bad.
+ * @return errorcode. 0 on success.
+ */
+int littlefs_sdmmc_erase(const struct lfs_config *c, lfs_block_t block);
+
+/**
+ * @brief Sync the state of the underlying SD card.
+ *
+ * Negative error codes are propogated to the user.
+ *
+ * @return errorcode. 0 on success.
+ */
+int littlefs_sdmmc_sync(const struct lfs_config *c);
 
 #ifdef __cplusplus
 }

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -9,7 +9,7 @@
 #include "esp_vfs.h"
 #include "esp_partition.h"
 #include "littlefs/lfs.h"
-#include <driver/sdmmc_types.h>
+#include <sdmmc_cmd.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/littlefs_esp_part.c
+++ b/src/littlefs_esp_part.c
@@ -14,8 +14,8 @@
 #include "littlefs_api.h"
 
 
-int littlefs_api_read(const struct lfs_config *c, lfs_block_t block,
-        lfs_off_t off, void *buffer, lfs_size_t size) {
+int littlefs_esp_part_read(const struct lfs_config *c, lfs_block_t block,
+                           lfs_off_t off, void *buffer, lfs_size_t size) {
     esp_littlefs_t * efs = c->context;
     size_t part_off = (block * c->block_size) + off;
     esp_err_t err = esp_partition_read(efs->partition, part_off, buffer, size);
@@ -26,8 +26,8 @@ int littlefs_api_read(const struct lfs_config *c, lfs_block_t block,
     return 0;
 }
 
-int littlefs_api_prog(const struct lfs_config *c, lfs_block_t block,
-        lfs_off_t off, const void *buffer, lfs_size_t size) {
+int littlefs_esp_part_write(const struct lfs_config *c, lfs_block_t block,
+                            lfs_off_t off, const void *buffer, lfs_size_t size) {
     esp_littlefs_t * efs = c->context;
     size_t part_off = (block * c->block_size) + off;
     esp_err_t err = esp_partition_write(efs->partition, part_off, buffer, size);
@@ -38,7 +38,7 @@ int littlefs_api_prog(const struct lfs_config *c, lfs_block_t block,
     return 0;
 }
 
-int littlefs_api_erase(const struct lfs_config *c, lfs_block_t block) {
+int littlefs_esp_part_erase(const struct lfs_config *c, lfs_block_t block) {
     esp_littlefs_t * efs = c->context;
     size_t part_off = block * c->block_size;
     esp_err_t err = esp_partition_erase_range(efs->partition, part_off, c->block_size);
@@ -50,7 +50,7 @@ int littlefs_api_erase(const struct lfs_config *c, lfs_block_t block) {
 
 }
 
-int littlefs_api_sync(const struct lfs_config *c) {
+int littlefs_esp_part_sync(const struct lfs_config *c) {
     /* Unnecessary for esp-idf */
     return 0;
 }

--- a/src/littlefs_sdmmc.c
+++ b/src/littlefs_sdmmc.c
@@ -1,0 +1,54 @@
+/**
+ * @file littlefs_sdmmc.c
+ * @brief Maps the HAL of sdmmc driver <-> littlefs
+ * @author Jackson Ming Hu <jackson@smartguide.com.au>
+ */
+
+#include <sdmmc_cmd.h>
+#include <sys/param.h>
+#include "littlefs_api.h"
+
+int littlefs_sdmmc_read(const struct lfs_config *c, lfs_block_t block, lfs_off_t off, void *buffer, lfs_size_t size)
+{
+    esp_littlefs_t * efs = c->context;
+    size_t part_off = (block * c->block_size) + off;
+
+    esp_err_t ret = sdmmc_read_sectors(efs->sdcard, buffer, block, MIN(size / efs->cfg.read_size, 1));
+    if (ret != ESP_OK) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "failed to read addr %08x, size %08x, err=0x%x", (unsigned int) part_off, (unsigned int) size, ret);
+        return LFS_ERR_IO;
+    }
+
+    return LFS_ERR_OK;
+}
+
+int littlefs_sdmmc_write(const struct lfs_config *c, lfs_block_t block, lfs_off_t off, const void *buffer, lfs_size_t size)
+{
+    esp_littlefs_t * efs = c->context;
+    size_t part_off = (block * c->block_size) + off;
+
+    esp_err_t ret = sdmmc_write_sectors(efs->sdcard, buffer, block, MIN(size / efs->cfg.prog_size, 1));
+    if (ret != ESP_OK) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "failed to write addr %08x, size %08x, err=0x%x", (unsigned int) part_off, (unsigned int) size, ret);
+        return LFS_ERR_IO;
+    }
+
+    return LFS_ERR_OK;
+}
+
+int littlefs_sdmmc_erase(const struct lfs_config *c, lfs_block_t block)
+{
+    esp_littlefs_t * efs = c->context;
+    esp_err_t ret = sdmmc_erase_sectors(efs->sdcard, block, 1, SDMMC_ERASE_ARG);
+    if (ret != ESP_OK) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Failed to erase block %lu: ret=0x%x %s", block, ret, esp_err_to_name(ret));
+        return LFS_ERR_IO;
+    }
+
+    return LFS_ERR_OK;
+}
+
+int littlefs_sdmmc_sync(const struct lfs_config *c)
+{
+    return LFS_ERR_OK; // Doesn't require & doesn't support sync
+}


### PR DESCRIPTION
Hi @BrianPugh 

As per discussed in issue https://github.com/joltwallet/esp_littlefs/issues/34 , here's my attempt for adding SD card support for this library.

Meanwhile, please be aware that:

1. I haven't tested my work yet, I will test it later this week. But you may have a read for the code if you would like to.
2. The `read_size`, `prog_size` and `block_size` in LittleFS configuration are forced to set to the same size of SD card sector. AFAIK this is normally 512 to 1024 bytes for some small industrial solderable SD NAND chip like [XTSD01GLGEAG](https://www.lcsc.com/product-detail/NAND-FLASH_XTX-XTSD01GLGEAG_C558837.html), or 4096-8192 bytes for other modern SDHC/SDXC cards.


Please feel free provide suggestions if you have any. Thanks.

Regards,
Jackson