### PR TITLE
Pin littlefs-python requirement for older versions of Python

### DIFF
--- a/image-building-requirements.txt
+++ b/image-building-requirements.txt
@@ -1,1 +1,3 @@
-littlefs-python>=0.7.1
+littlefs-python>=0.7.1; python_version >= "3.8"
+# littlefs-python has to be pinned to a specific version due to minimal Python version in IDF v5.0 and v5.1
+littlefs-python==0.10.0; python_version < "3.8"


### PR DESCRIPTION
Hi again.

We finally got to merge backports of LittleFS example in ESP-IDF to v5.0 and v5.1 branches but the CI is broken again... Due to me not fully understanding virtual environments in Python. However this change should fix it.  ESP-IDF v5.0 and v5.1 has minimal version requirement for Python to be 3.7 so we released `littlefs-python` version 0.9.3 (https://github.com/jrast/littlefs-python/pull/78) while ago (it seems 0.10.0 should also be compatible) and this change should make sure the virtual environment created during fetching `joltwallet/littlefs` (esp_littlefs) from component manager will have the exact version we need.

@BrianPugh 

Thank you.