### PR TITLE
Update LFS to v2.10.0

### DIFF
--- a/test/test_littlefs.c
+++ b/test/test_littlefs.c
@@ -156,7 +156,8 @@ TEST_CASE("w+ mode read and write file", "[littlefs]")
 
 TEST_CASE("can open maximum number of files", "[littlefs]")
 {
-    size_t max_files = 61;  /* account for stdin, stdout, stderr, esp-idf defaults to maximum 64 file descriptors */
+    size_t max_files = FOPEN_MAX - 3;  /* account for stdin, stdout, stderr, esp-idf defaults to maximum 64 file descriptors */
+
     test_setup();
     test_littlefs_open_max_files("/littlefs/f", max_files);
     test_teardown();

--- a/test/test_littlefs_static_partition.c
+++ b/test/test_littlefs_static_partition.c
@@ -137,7 +137,7 @@ TEST_CASE("grow filesystem", "[littlefs]")
       .partition = (const esp_partition_t *) &partition,
     };
 
-    uint32_t shrink_bytes;
+    size_t shrink_bytes;
 
     /* Format a smaller partition */
     {
@@ -158,7 +158,7 @@ TEST_CASE("grow filesystem", "[littlefs]")
 
     /* Mount, ensure that it DOES grow */
     {
-        uint32_t grow_bytes;
+        size_t grow_bytes;
         conf.grow_on_mount = true;
         TEST_ESP_OK(esp_vfs_littlefs_register(&conf));
         TEST_ESP_OK(esp_littlefs_partition_info(&partition, &grow_bytes, NULL));


### PR DESCRIPTION
Updates littlefs submodule to [v2.10.0](https://github.com/littlefs-project/littlefs/releases/tag/v2.10.0)

Cherry-picks the unit-test fixes from @haberturdeur in #205.