### PR TITLE
Fix wrong limit on SD card block count

### DIFF
--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -933,21 +933,11 @@ static esp_err_t esp_littlefs_init_sdcard(esp_littlefs_t** efs, sdmmc_card_t* sd
         (*efs)->cfg.erase = littlefs_sdmmc_erase;
         (*efs)->cfg.sync  = littlefs_sdmmc_sync;
 
-        size_t max_allowed_blk_cnt = 0;
-        if (((uint64_t)sdcard->csd.capacity * (uint64_t)sdcard->csd.sector_size) > SIZE_MAX) {
-            max_allowed_blk_cnt = SIZE_MAX / sdcard->csd.sector_size;
-            ESP_LOGW(ESP_LITTLEFS_TAG, "SD card is too big (sector=%d, count=%d; total=%llu bytes), throttling to maximum possible %u blocks",
-                     sdcard->csd.sector_size, sdcard->csd.capacity,
-                     (((uint64_t)sdcard->csd.capacity * (uint64_t)sdcard->csd.sector_size)), max_allowed_blk_cnt);
-        } else {
-            max_allowed_blk_cnt = sdcard->csd.capacity;
-        }
-
         // block device configuration
         (*efs)->cfg.read_size = sdcard->csd.sector_size;
         (*efs)->cfg.prog_size = sdcard->csd.sector_size;
         (*efs)->cfg.block_size = sdcard->csd.sector_size;
-        (*efs)->cfg.block_count = max_allowed_blk_cnt;
+        (*efs)->cfg.block_count = sdcard->csd.capacity;
         (*efs)->cfg.cache_size = MAX(CONFIG_LITTLEFS_CACHE_SIZE, sdcard->csd.sector_size); // Must not be smaller than SD sector size
         (*efs)->cfg.lookahead_size = CONFIG_LITTLEFS_LOOKAHEAD_SIZE;
         (*efs)->cfg.block_cycles = CONFIG_LITTLEFS_BLOCK_CYCLES;


### PR DESCRIPTION
This is the fix for issue https://github.com/joltwallet/esp_littlefs/issues/211 and https://github.com/joltwallet/esp_littlefs/issues/173

Since people are asking for supporting bigger SD card, I think let's probably lift the limit anyway. But bear in mind this may have data corruption or it might take longer time to initialise (to prepare for super blocks I guess?). So far I've only tested on those XTX SD NAND chips earlier, and I never tested with a larger SD card. I'm also busy working on something higher priority at work so I can't arrange a test for now. 

Anyway, please test it on your own throughly before putting into production. If people are happy then maybe we can merge this.

cc @BrianPugh 