### PR TITLE
fix: esp-idf build issue occurred while adding ESP8266 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ list(APPEND SOURCES src/esp_littlefs.c src/littlefs_esp_part.c src/lfs_config.c)
 
 if(CONFIG_LITTLEFS_SDMMC_SUPPORT)
     list(APPEND SOURCES src/littlefs_sdmmc.c)
+endif()
+
+if(NOT CONFIG_IDF_TARGET_ESP8266)
     list(APPEND pub_requires sdmmc)
 endif()
 


### PR DESCRIPTION
Referring to this comment [here](https://github.com/joltwallet/esp_littlefs/pull/215#issuecomment-2626946692), adding this fix to resolve the build issue.