### PR TITLE
Conditional include of sdmmc depending on if IDF_TARGET is not esp8266

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,15 @@ cmake_minimum_required(VERSION 3.10)
 file(GLOB SOURCES src/littlefs/*.c)
 list(APPEND SOURCES src/esp_littlefs.c src/littlefs_esp_part.c src/lfs_config.c)
 
-if(CONFIG_LITTLEFS_SDMMC_SUPPORT)
-    list(APPEND SOURCES src/littlefs_sdmmc.c)
+if(IDF_TARGET STREQUAL "esp8266")
+    # ESP8266 configuration here
+else()
+    # non-ESP8266 configuration
     list(APPEND pub_requires sdmmc)
+
+    if(CONFIG_LITTLEFS_SDMMC_SUPPORT)
+        list(APPEND SOURCES src/littlefs_sdmmc.c)
+    endif()
 endif()
 
 if(IDF_VERSION_MAJOR GREATER_EQUAL 5)


### PR DESCRIPTION
Alternative solution to #218. I'm more confident this will have the desired impact.