### PR TITLE
Update mtime on close

### DIFF
--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -2394,8 +2394,12 @@ static time_t esp_littlefs_get_updated_time(esp_littlefs_t *efs, vfs_littlefs_fi
     if(path){
         t = esp_littlefs_get_mtime_attr(efs, path);
     }
-    else{
+    elif(file){
         t = file->lfs_attr_time_buffer;
+    }
+    else{
+        // Invalid input arguments.
+        assert(0);
     }
     if( 0 == t ) t = esp_random();
     else t += 1;

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -19,7 +19,12 @@
 extern "C" {
 #endif
 
-#define ESP_LITTLEFS_ATTR_COUNT 1
+#if CONFIG_LITTLEFS_USE_MTIME
+    #define ESP_LITTLEFS_ATTR_COUNT 1
+#else
+    #define ESP_LITTLEFS_ATTR_COUNT 0
+#endif
+
 /**
  * @brief a file descriptor
  * That's also a singly linked list used for keeping tracks of all opened file descriptor 
@@ -42,7 +47,10 @@ typedef struct _vfs_littlefs_file_t {
     /* Allocate all other necessary buffers */
     struct lfs_file_config lfs_file_config;
     uint8_t lfs_buffer[CONFIG_LITTLEFS_CACHE_SIZE];
+#if ESP_LITTLEFS_ATTR_COUNT
     struct lfs_attr lfs_attr[ESP_LITTLEFS_ATTR_COUNT];
+    time_t lfs_attr_time_buffer;
+#endif
 
     uint32_t hash;
     struct _vfs_littlefs_file_t * next;       /*!< Pointer to next file in Singly Linked List */

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -9,7 +9,7 @@
 #include "esp_vfs.h"
 #include "esp_partition.h"
 #include "littlefs/lfs.h"
-#include <sdkconfig.h>
+#include "sdkconfig.h"
 
 #ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
 #include <sdmmc_cmd.h>
@@ -19,6 +19,7 @@
 extern "C" {
 #endif
 
+#define ESP_LITTLEFS_ATTR_COUNT 1
 /**
  * @brief a file descriptor
  * That's also a singly linked list used for keeping tracks of all opened file descriptor 
@@ -37,7 +38,13 @@ extern "C" {
  */
 typedef struct _vfs_littlefs_file_t {
     lfs_file_t file;
-    uint32_t   hash;
+
+    /* Allocate all other necessary buffers */
+    struct lfs_file_config lfs_file_config;
+    uint8_t lfs_buffer[CONFIG_LITTLEFS_CACHE_SIZE];
+    struct lfs_attr lfs_attr[ESP_LITTLEFS_ATTR_COUNT];
+
+    uint32_t hash;
     struct _vfs_littlefs_file_t * next;       /*!< Pointer to next file in Singly Linked List */
 #ifndef CONFIG_LITTLEFS_USE_ONLY_HASH
     char     * path;


### PR DESCRIPTION
## Features
* Less frequent, bigger `mallocs` to ever so slightly increase efficiency and reduce heap fragmentation.
* `mtime` is now updated on `flush` and `close`, instead of on `open`. Addresses #229.
* `mtime` `nonce` feature has been broken on esp-idf >v5, and is now fixed. Noone has reported this, which I guess means very little people use this feature 🙈 .

## TODO
- [x] Directories `mtime` are still not updated when files mtime is updated; I'll have to see if it's possible to do this.