### PR TITLE
Fix LITTLEFS_MALLOC_STRATEGY_SPIRAM depends.

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -243,7 +243,7 @@ menu "LittleFS"
 
         config LITTLEFS_MALLOC_STRATEGY_SPIRAM
             bool "SPIRAM heap"
-            depends on SPIRAM_USE_MALLOC && ESP32_SPIRAM_SUPPORT
+            depends on SPIRAM_USE_MALLOC || SPIRAM_USE_CAPS_ALLOC
             help
                 Uses ESP-IDF heap_caps_malloc to allocate from SPIRAM heap.
 


### PR DESCRIPTION
ESP32_SPIRAM_SUPPORT has been renamed to SPIRAM since IDF 5.0: https://github.com/espressif/esp-idf/commit/0687daf2c85b916fa0a17a29a950b4eb938cc12a#diff-23044c90e9c0d809dc2befbe42491cd077bf06445cd24e6acba7784ea5f28b27R20

Also checking for SPIRAM support is not necessary, as SPIRAM_USE_MALLOC already depends on SPIRAM.

Additionally allocating using heap_caps_malloc(..., MALLOC_CAP_SPIRAM) is also possible if SPIRAM_USE_CAPS_ALLOC is set (then SPIRAM is **only** allocatable with heap_caps_malloc, not with malloc)