### PR TITLE
Add support for mmapping partitions

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -260,6 +260,7 @@ menu "LittleFS"
         default "n"
         help
             Use esp_partition_mmap to map the partitions to memory, which can provide a significant
-            performance boost in some cases.
+            performance boost in some cases. Make sure the chip you're using has enough available address
+            space to map the partition (for the ESP32 there is 4MB available).
 
 endmenu

--- a/Kconfig
+++ b/Kconfig
@@ -255,4 +255,11 @@ menu "LittleFS"
         help
             Selects whether littlefs performs runtime assert checks.
 
+    config LITTLEFS_MMAP_PARTITION
+        bool "Memory map LITTLEFS partitions"
+        default "n"
+        help
+            Use esp_partition_mmap to map the partitions to memory, which can provide a significant
+            performance boost in some cases.
+
 endmenu

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -71,6 +71,12 @@ typedef struct {
 #endif
 
     const esp_partition_t* partition;         /*!< The partition on which littlefs is located */
+
+#ifdef CONFIG_LITTLEFS_MMAP_PARTITION
+    const void *mmap_data;                    /*!< Buffer of mmapped partition */
+    esp_partition_mmap_handle_t mmap_handle;  /*!< Handle to mmapped partition */
+#endif
+
     char base_path[ESP_VFS_PATH_MAX+1];       /*!< Mount point */
 
     struct lfs_config cfg;                    /*!< littlefs Mount configuration */
@@ -82,6 +88,18 @@ typedef struct {
     uint16_t             fd_count;            /*!< The count of opened file descriptor used to speed up computation */
     bool                 read_only;           /*!< Filesystem is read-only */
 } esp_littlefs_t;
+
+#ifdef CONFIG_LITTLEFS_MMAP_PARTITION
+/**
+ * @brief Read a region in a block, only for use with an mmapped partition.
+ *
+ * Negative error codes are propogated to the user.
+ *
+ * @return errorcode. 0 on success.
+ */
+int littlefs_esp_part_read_mmap(const struct lfs_config *c, lfs_block_t block,
+                           lfs_off_t off, void *buffer, lfs_size_t size);
+#endif
 
 /**
  * @brief Read a region in a block.

--- a/src/littlefs_esp_part.c
+++ b/src/littlefs_esp_part.c
@@ -13,6 +13,19 @@
 #include "esp_littlefs.h"
 #include "littlefs_api.h"
 
+#ifdef CONFIG_LITTLEFS_MMAP_PARTITION
+int littlefs_esp_part_read_mmap(const struct lfs_config *c, lfs_block_t block,
+                           lfs_off_t off, void *buffer, lfs_size_t size) {
+    esp_littlefs_t * efs = c->context;
+    size_t part_off = (block * c->block_size) + off;
+    if (part_off > efs->partition->size || part_off + size > efs->partition->size) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "attempt to read out bounds of mmaped region %08x-%08x", (unsigned int)part_off, (unsigned int)(part_off + size));
+        return LFS_ERR_IO;
+    }
+    memcpy(buffer, efs->mmap_data + part_off, size);
+    return 0;
+}
+#endif
 
 int littlefs_esp_part_read(const struct lfs_config *c, lfs_block_t block,
                            lfs_off_t off, void *buffer, lfs_size_t size) {


### PR DESCRIPTION
Hi,

This adds support for CONFIG_LITTLEFS_MMAP_PARTITION option which will mmap the partition once during initialisation. This can provide a significant performance boost, specially when running with encryption (all reads go through an mmapped buffer, which is then munmapped).

I ran the benchmarks in the unit test app and got these results with **encryption enabled** and **mmap support disabled**:

```
LittleFS:
88000 bytes written in 3258257 us
88000 bytes written in 3345849 us
88000 bytes written in 3411501 us
88000 bytes written in 3336487 us
88000 bytes written in 3375146 us

88000 bytes read in 3792006 us
88000 bytes read in 3624328 us
88000 bytes read in 3586450 us
88000 bytes read in 3477757 us
88000 bytes read in 3349822 us

deleted file 0 in 421254 us
deleted file 1 in 372979 us
deleted file 2 in 324646 us
deleted file 3 in 285972 us
deleted file 4 in 286021 us

Total (440000) Write: 16727240 us
Total (440000) Read: 17830363 us
Total (440000) Delete: 1690872 us
```

Here are the results with **encryption enabled** and **mmap support enabled**:

```
LittleFS:
88000 bytes written in 3296084 us
88000 bytes written in 3298136 us
88000 bytes written in 3296169 us
88000 bytes written in 3297763 us
88000 bytes written in 3287617 us

88000 bytes read in 739860 us
88000 bytes read in 740905 us
88000 bytes read in 740026 us
88000 bytes read in 740646 us
88000 bytes read in 739835 us

deleted file 0 in 12121 us
deleted file 1 in 11863 us
deleted file 2 in 11844 us
deleted file 3 in 11789 us
deleted file 4 in 11803 us

Total (440000) Write: 16475769 us
Total (440000) Read: 3701272 us
Total (440000) Delete: 59420 us
```

So it is about 5x increase in read performance, and **28x** delete performance.