### PR TITLE
Lvgl littlefs port

### DIFF
--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -7,6 +7,8 @@
 #include <stdbool.h>
 #include "esp_partition.h"
 
+#include "littlefs/lfs.h"
+
 #ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
 #include <sdmmc_cmd.h>
 #endif

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -49,6 +49,27 @@ typedef struct {
 } esp_vfs_littlefs_conf_t;
 
 /**
+ * Initialize and mount LittleFS for LVGL integration.
+ *
+ * This helper initializes a LittleFS instance using the given configuration
+ * and returns a pointer to the underlying lfs_t object, allowing direct access
+ * for LVGL file system operations.
+ *
+ * Unlike esp_vfs_littlefs_register(), this function does not register
+ * the filesystem to ESP-IDF VFS. It is designed for use cases where LVGL
+ * manages file access directly through lv_fs API.
+
+ *
+ * @param   conf                      Pointer to esp_vfs_littlefs_conf_t configuration structure
+ *
+ * @return  
+ *          - Pointer to lfs_t        if initialization and mount succeed  
+ *          - NULL                    if initialization or mount fails
+ */
+lfs_t * esp_littlefs_lvgl_port_init(const esp_vfs_littlefs_conf_t * conf);
+
+
+/**
  * Register and mount (if configured to) littlefs to VFS with given path prefix.
  *
  * @param   conf                      Pointer to esp_vfs_littlefs_conf_t configuration structure

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -48,6 +48,51 @@ typedef struct {
     uint8_t grow_on_mount:1;          /**< Grow filesystem to match partition size on mount.*/
 } esp_vfs_littlefs_conf_t;
 
+
+/**
+ * Initialize and mount LittleFS for LVGL integration.
+ *
+ * This helper initializes a LittleFS instance using the given configuration
+ * and returns a pointer to the underlying lfs_t object, allowing direct access
+ * for LVGL file system operations.
+ *
+ * Unlike esp_vfs_littlefs_register(), this function does not register
+ * the filesystem to ESP-IDF VFS. It is designed for use cases where LVGL
+ * manages file access directly through lv_fs API.
+ *
+ * Typical usage:
+ * @code
+ * esp_vfs_littlefs_conf_t conf = {
+ *     .base_path = BSP_LITTLEFS_MOUNT_POINT,
+ *     .partition_label = BSP_LITTLEFS_PARTITION_LABEL,
+ *     .format_if_mount_failed = true,
+ *     .dont_mount = false,
+ * };
+ *
+ * lv_fs_littlefs_init();
+ * lfs_t *lfs = esp_littlefs_lvgl_port_init(&conf);
+ * if (lfs != NULL) {
+ *     lv_littlefs_set_handler(lfs);
+ *     lv_fs_file_t file;
+ *     lv_fs_res_t ret = lv_fs_open(&file, "A:/example.txt", LV_FS_MODE_RD);
+ *     if (ret == LV_FS_RES_OK) {
+ *         char buffer[100];
+ *         uint32_t bytes;
+ *         lv_fs_read(&file, buffer, sizeof(buffer)-1, &bytes);
+ *         buffer[bytes] = '\0';
+ *         printf("%s\n", buffer);
+ *     }
+ * }
+ * @endcode
+ *
+ * @param   conf                      Pointer to esp_vfs_littlefs_conf_t configuration structure
+ *
+ * @return  
+ *          - Pointer to lfs_t        if initialization and mount succeed  
+ *          - NULL                    if initialization or mount fails
+ */
+lfs_t * esp_littlefs_lvgl_port_init(const esp_vfs_littlefs_conf_t * conf);
+
 /**
  * Register and mount (if configured to) littlefs to VFS with given path prefix.
  *

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -48,51 +48,6 @@ typedef struct {
     uint8_t grow_on_mount:1;          /**< Grow filesystem to match partition size on mount.*/
 } esp_vfs_littlefs_conf_t;
 
-
-/**
- * Initialize and mount LittleFS for LVGL integration.
- *
- * This helper initializes a LittleFS instance using the given configuration
- * and returns a pointer to the underlying lfs_t object, allowing direct access
- * for LVGL file system operations.
- *
- * Unlike esp_vfs_littlefs_register(), this function does not register
- * the filesystem to ESP-IDF VFS. It is designed for use cases where LVGL
- * manages file access directly through lv_fs API.
- *
- * Typical usage:
- * @code
- * esp_vfs_littlefs_conf_t conf = {
- *     .base_path = BSP_LITTLEFS_MOUNT_POINT,
- *     .partition_label = BSP_LITTLEFS_PARTITION_LABEL,
- *     .format_if_mount_failed = true,
- *     .dont_mount = false,
- * };
- *
- * lv_fs_littlefs_init();
- * lfs_t *lfs = esp_littlefs_lvgl_port_init(&conf);
- * if (lfs != NULL) {
- *     lv_littlefs_set_handler(lfs);
- *     lv_fs_file_t file;
- *     lv_fs_res_t ret = lv_fs_open(&file, "A:/example.txt", LV_FS_MODE_RD);
- *     if (ret == LV_FS_RES_OK) {
- *         char buffer[100];
- *         uint32_t bytes;
- *         lv_fs_read(&file, buffer, sizeof(buffer)-1, &bytes);
- *         buffer[bytes] = '\0';
- *         printf("%s\n", buffer);
- *     }
- * }
- * @endcode
- *
- * @param   conf                      Pointer to esp_vfs_littlefs_conf_t configuration structure
- *
- * @return  
- *          - Pointer to lfs_t        if initialization and mount succeed  
- *          - NULL                    if initialization or mount fails
- */
-lfs_t * esp_littlefs_lvgl_port_init(const esp_vfs_littlefs_conf_t * conf);
-
 /**
  * Register and mount (if configured to) littlefs to VFS with given path prefix.
  *

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -425,6 +425,47 @@ static esp_vfs_fs_ops_t s_vfs_littlefs = {
 };
 
 #endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+
+
+lfs_t * esp_littlefs_lvgl_port_init(const esp_vfs_littlefs_conf_t * conf)
+{
+    int index;
+    assert(conf->base_path);
+    esp_err_t err = esp_littlefs_init(conf, &index);
+    if (err != ESP_OK) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Failed to initialize LittleFS");
+        return NULL;
+    }
+    
+    strlcat(_efs[index]->base_path, conf->base_path, ESP_VFS_PATH_MAX + 1);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+    int flags = ESP_VFS_FLAG_CONTEXT_PTR | ESP_VFS_FLAG_STATIC; 
+    if (conf->read_only) {
+        flags |= ESP_VFS_FLAG_READONLY_FS;
+    }
+    err = esp_vfs_register_fs(conf->base_path, &s_vfs_littlefs, flags, _efs[index]);
+#else
+    err = esp_vfs_register(conf->base_path, &vfs, _efs[index]);
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+    if (err != ESP_OK) {
+        esp_littlefs_free(&_efs[index]);
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Failed to register Littlefs to \"%s\"", conf->base_path);
+        return NULL;
+    }
+    size_t total = 0, used = 0;
+    esp_err_t ret_val = esp_littlefs_info(conf->partition_label, &total, &used);
+    if (ret_val != ESP_OK)
+    {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Failed to get LittleFs partition information (%s)", esp_err_to_name(ret_val));
+    }
+    else
+    {
+        ESP_LOGI(ESP_LITTLEFS_TAG, "Partition size: total: %d, used: %d", total, used);
+    }
+
+    return _efs[index]->fs;
+}
+
 esp_err_t esp_vfs_littlefs_register(const esp_vfs_littlefs_conf_t * conf)
 {
     int index;

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -425,47 +425,6 @@ static esp_vfs_fs_ops_t s_vfs_littlefs = {
 };
 
 #endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
-
-
-lfs_t * lv_littlefs_port_init(const esp_vfs_littlefs_conf_t * conf)
-{
-    int index;
-    assert(conf->base_path);
-    esp_err_t err = esp_littlefs_init(conf, &index);
-    if (err != ESP_OK) {
-        ESP_LOGE(ESP_LITTLEFS_TAG, "Failed to initialize LittleFS");
-        return NULL;
-    }
-    
-    strlcat(_efs[index]->base_path, conf->base_path, ESP_VFS_PATH_MAX + 1);
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
-    int flags = ESP_VFS_FLAG_CONTEXT_PTR | ESP_VFS_FLAG_STATIC; 
-    if (conf->read_only) {
-        flags |= ESP_VFS_FLAG_READONLY_FS;
-    }
-    err = esp_vfs_register_fs(conf->base_path, &s_vfs_littlefs, flags, _efs[index]);
-#else
-    err = esp_vfs_register(conf->base_path, &vfs, _efs[index]);
-#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
-    if (err != ESP_OK) {
-        esp_littlefs_free(&_efs[index]);
-        ESP_LOGE(ESP_LITTLEFS_TAG, "Failed to register Littlefs to \"%s\"", conf->base_path);
-        return NULL;
-    }
-    size_t total = 0, used = 0;
-    esp_err_t ret_val = esp_littlefs_info(conf->partition_label, &total, &used);
-    if (ret_val != ESP_OK)
-    {
-        ESP_LOGE(ESP_LITTLEFS_TAG, "Failed to get LittleFs partition information (%s)", esp_err_to_name(ret_val));
-    }
-    else
-    {
-        ESP_LOGI(ESP_LITTLEFS_TAG, "Partition size: total: %d, used: %d", total, used);
-    }
-
-    return _efs[index]->fs;
-}
-
 esp_err_t esp_vfs_littlefs_register(const esp_vfs_littlefs_conf_t * conf)
 {
     int index;

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -425,6 +425,47 @@ static esp_vfs_fs_ops_t s_vfs_littlefs = {
 };
 
 #endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+
+
+lfs_t * lv_littlefs_port_init(const esp_vfs_littlefs_conf_t * conf)
+{
+    int index;
+    assert(conf->base_path);
+    esp_err_t err = esp_littlefs_init(conf, &index);
+    if (err != ESP_OK) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Failed to initialize LittleFS");
+        return NULL;
+    }
+    
+    strlcat(_efs[index]->base_path, conf->base_path, ESP_VFS_PATH_MAX + 1);
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+    int flags = ESP_VFS_FLAG_CONTEXT_PTR | ESP_VFS_FLAG_STATIC; 
+    if (conf->read_only) {
+        flags |= ESP_VFS_FLAG_READONLY_FS;
+    }
+    err = esp_vfs_register_fs(conf->base_path, &s_vfs_littlefs, flags, _efs[index]);
+#else
+    err = esp_vfs_register(conf->base_path, &vfs, _efs[index]);
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+    if (err != ESP_OK) {
+        esp_littlefs_free(&_efs[index]);
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Failed to register Littlefs to \"%s\"", conf->base_path);
+        return NULL;
+    }
+    size_t total = 0, used = 0;
+    esp_err_t ret_val = esp_littlefs_info(conf->partition_label, &total, &used);
+    if (ret_val != ESP_OK)
+    {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Failed to get LittleFs partition information (%s)", esp_err_to_name(ret_val));
+    }
+    else
+    {
+        ESP_LOGI(ESP_LITTLEFS_TAG, "Partition size: total: %d, used: %d", total, used);
+    }
+
+    return _efs[index]->fs;
+}
+
 esp_err_t esp_vfs_littlefs_register(const esp_vfs_littlefs_conf_t * conf)
 {
     int index;


### PR DESCRIPTION
# Add `esp_littlefs_lvgl_port_init(const esp_vfs_littlefs_conf_t * conf)` for LVGL Integration

##  Summary
This PR introduces a helper function:
```c
lfs_t * esp_littlefs_lvgl_port_init(const esp_vfs_littlefs_conf_t * conf);
```
When using **LVGL** with **LittleFS**, developers often need to access the internal `lfs_t` object to implement file system callbacks (`lv_fs_open`, `lv_fs_read`, etc.).
It allows developers to **initialize and mount LittleFS** directly and obtain a pointer to its internal `lfs_t` object, making it simple to integrate with **LVGL’s filesystem driver**.

##  Example Usage

```c
#include "esp_littlefs.h"
#include "lvgl.h"

void app_main(void)
{
    esp_vfs_littlefs_conf_t conf = {
        .base_path = BSP_LITTLEFS_MOUNT_POINT,
        .partition_label = BSP_LITTLEFS_PARTITION_LABEL,
        .format_if_mount_failed = true,
        .dont_mount = false,
    };
    lv_fs_littlefs_init();
    lfs_t *lfs = esp_littlefs_lvgl_port_init(&conf);
    if (lfs != NULL)
    {
        lv_littlefs_set_handler(lfs);

        lv_fs_file_t file;
        lv_fs_res_t ret = lv_fs_open(&file, "A:/example.txt", LV_FS_MODE_RD);
        if (ret != LV_FS_RES_OK)
        {
            ESP_LOGI("LVGL_FS", "lv_fs_open failed %d", (int)ret);
            return;
        }

        char *buffer = malloc(100);
        uint32_t bytes = 0;
        lv_fs_read(&file, buffer, 100, &bytes);
        buffer[bytes] = '\0';
        printf("%s\n", buffer);
        free(buffer);
    }
}
```

---

## Enviroment
- ESP-IDF v5.5.1
- LVGL 9.3.0
---

