### PR TITLE
fix implicit declaration of function time()

### DIFF
--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -22,6 +22,7 @@
 #include <sys/fcntl.h>
 #include <sys/lock.h>
 #include <sys/param.h>
+#include <time.h>
 #include <unistd.h>
 #include "esp_random.h"
 


### PR DESCRIPTION
This change fixes compilation warning with enabled `CONFIG_LIBC_PICOLIBC`:

```
managed_components/joltwallet__littlefs/src/esp_littlefs.c:2403:9: error: implicit declaration of function 'time' [-Wimplicit-function-declaration]
 2403 |     t = time(NULL);
 ```