### PR TITLE
Add legacy (v4.4.x) toolchain support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,12 @@ else()
     list(APPEND pub_requires esp_partition)
 endif()
 
-list(APPEND priv_requires esptool_py spi_flash vfs)
+set(priv_requires esptool_py vfs)
+if(idf_version VERSION_LESS "5.0")
+    list(APPEND priv_requires spi_flash)
+else()
+    list(APPEND priv_requires esp_partition)
+endif()
 
 idf_component_register(
     SRCS ${SOURCES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,15 @@ file(GLOB SOURCES src/littlefs/*.c)
 list(APPEND SOURCES src/esp_littlefs.c src/littlefs_esp_part.c src/lfs_config.c)
 
 idf_build_get_property(idf_version IDF_VERSION)
-string(REPLACE "." ";" version_list ${idf_version})
-list(GET version_list 0 idf_version_major)
+if(idf_version)
+    string(REPLACE "." ";" version_list ${idf_version})
+    list(GET version_list 0 idf_version_major)
+else()
+    idf_build_get_property(idf_version_major IDF_VERSION_MAJOR)
+endif()
+if(NOT idf_version_major)
+    set(idf_version_major 4)
+endif()
 
 if(IDF_TARGET STREQUAL "esp8266")
     # ESP8266 configuration here

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.10)
 file(GLOB SOURCES src/littlefs/*.c)
 list(APPEND SOURCES src/esp_littlefs.c src/littlefs_esp_part.c src/lfs_config.c)
 
+idf_build_get_property(idf_version IDF_VERSION)
+
 if(IDF_TARGET STREQUAL "esp8266")
     # ESP8266 configuration here
 else()
@@ -14,7 +16,12 @@ else()
     endif()
 endif()
 
-list(APPEND pub_requires esp_partition)
+if(idf_version VERSION_LESS "5.0")
+    list(APPEND pub_requires spi_flash)
+else()
+    list(APPEND pub_requires esp_partition)
+endif()
+
 list(APPEND priv_requires esptool_py spi_flash vfs)
 
 idf_component_register(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ file(GLOB SOURCES src/littlefs/*.c)
 list(APPEND SOURCES src/esp_littlefs.c src/littlefs_esp_part.c src/lfs_config.c)
 
 idf_build_get_property(idf_version IDF_VERSION)
+string(REPLACE "." ";" version_list ${idf_version})
+list(GET version_list 0 idf_version_major)
 
 if(IDF_TARGET STREQUAL "esp8266")
     # ESP8266 configuration here
@@ -57,3 +59,5 @@ endif()
 if(NOT CONFIG_LITTLEFS_ASSERTS)
     target_compile_definitions(${COMPONENT_LIB} PUBLIC -DLFS_NO_ASSERT)
 endif()
+
+target_compile_definitions(${COMPONENT_LIB} PUBLIC -DESP_LITTLEFS_IDF_VERSION_MAJOR=${idf_version_major})

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -2,4 +2,4 @@ version: "1.20.3"
 description: LittleFS is a small fail-safe filesystem for micro-controllers.
 url: https://github.com/joltwallet/esp_littlefs
 dependencies:
-  idf: ">=5.0"
+  idf: ">=4.4"

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -5,7 +5,13 @@
 #include "esp_err.h"
 #include "esp_idf_version.h"
 #include <stdbool.h>
+#include <stdint.h>
+
+#if __has_include("esp_partition.h")
 #include "esp_partition.h"
+#else
+typedef struct esp_partition_t esp_partition_t;
+#endif
 
 #ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
 #include <sdmmc_cmd.h>

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -6,12 +6,7 @@
 #include "esp_idf_version.h"
 #include <stdbool.h>
 #include <stdint.h>
-
-#if __has_include("esp_partition.h")
 #include "esp_partition.h"
-#else
-typedef struct esp_partition_t esp_partition_t;
-#endif
 
 #ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
 #include <sdmmc_cmd.h>

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -5,8 +5,20 @@
 #include "esp_err.h"
 #include "esp_idf_version.h"
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#if !defined(ESP_LITTLEFS_IDF_VERSION_MAJOR)
+#define ESP_LITTLEFS_IDF_VERSION_MAJOR 4
+#endif
+
+#if ESP_LITTLEFS_IDF_VERSION_MAJOR < 5
 #include "esp_partition.h"
+#else
+typedef struct esp_partition_t esp_partition_t;
+esp_err_t esp_partition_read(const esp_partition_t* partition, size_t src_offset, void* dst, size_t size);
+esp_err_t esp_partition_write(const esp_partition_t* partition, size_t dst_offset, const void* src, size_t size);
+esp_err_t esp_partition_erase_range(const esp_partition_t* partition, size_t offset, size_t size);
+#endif
 
 #ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
 #include <sdmmc_cmd.h>

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -26,8 +26,10 @@
 #include <unistd.h>
 #include "esp_random.h"
 
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
-#error "esp_littlefs requires esp-idf >=5.0"
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 0)
+#error "esp_littlefs requires esp-idf >=4.4"
+#elif defined(CONFIG_LITTLEFS_SDMMC_SUPPORT) && ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
+#error "CONFIG_LITTLEFS_SDMMC_SUPPORT requires esp-idf >=5.0"
 #endif
 
 
@@ -35,7 +37,11 @@
 #include <sdmmc_cmd.h>
 #endif
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #include "spi_flash_mmap.h"
+#else
+#include "esp_spi_flash.h"
+#endif
 
 #if CONFIG_IDF_TARGET_ESP32
 #include "esp32/rom/spi_flash.h"

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -9,6 +9,7 @@
 #endif // LOG_LOCAL_LEVEL
 
 #include "esp_littlefs.h"
+#include "esp_partition.h"
 #include "littlefs/lfs.h"
 #include "sdkconfig.h"
 #include "esp_log.h"

--- a/src/littlefs_esp_part.c
+++ b/src/littlefs_esp_part.c
@@ -86,4 +86,3 @@ int littlefs_esp_part_sync(const struct lfs_config *c) {
     /* Unnecessary for esp-idf */
     return 0;
 }
-

--- a/src/littlefs_esp_part.c
+++ b/src/littlefs_esp_part.c
@@ -7,7 +7,7 @@
 //#define ESP_LOCAL_LOG_LEVEL ESP_LOG_INFO
 
 #include "esp_log.h"
-#if __has_include("esp_partition.h")
+ #if ESP_LITTLEFS_IDF_VERSION_MAJOR >= 5
 #include "esp_partition.h"
 #else
 typedef struct esp_partition_t esp_partition_t;

--- a/src/littlefs_esp_part.c
+++ b/src/littlefs_esp_part.c
@@ -11,6 +11,10 @@
 #include "esp_partition.h"
 #else
 typedef struct esp_partition_t esp_partition_t;
+typedef int esp_err_t;
+esp_err_t esp_partition_read(const esp_partition_t* partition, size_t src_offset, void* dst, size_t size);
+esp_err_t esp_partition_write(const esp_partition_t* partition, size_t dst_offset, const void* src, size_t size);
+esp_err_t esp_partition_erase_range(const esp_partition_t* partition, size_t offset, size_t size);
 #endif
 #include "esp_vfs.h"
 #include "littlefs/lfs.h"

--- a/src/littlefs_esp_part.c
+++ b/src/littlefs_esp_part.c
@@ -7,7 +7,11 @@
 //#define ESP_LOCAL_LOG_LEVEL ESP_LOG_INFO
 
 #include "esp_log.h"
+#if __has_include("esp_partition.h")
 #include "esp_partition.h"
+#else
+typedef struct esp_partition_t esp_partition_t;
+#endif
 #include "esp_vfs.h"
 #include "littlefs/lfs.h"
 #include "esp_littlefs.h"

--- a/src/littlefs_esp_part.c
+++ b/src/littlefs_esp_part.c
@@ -7,15 +7,6 @@
 //#define ESP_LOCAL_LOG_LEVEL ESP_LOG_INFO
 
 #include "esp_log.h"
- #if ESP_LITTLEFS_IDF_VERSION_MAJOR >= 5
-#include "esp_partition.h"
-#else
-typedef struct esp_partition_t esp_partition_t;
-typedef int esp_err_t;
-esp_err_t esp_partition_read(const esp_partition_t* partition, size_t src_offset, void* dst, size_t size);
-esp_err_t esp_partition_write(const esp_partition_t* partition, size_t dst_offset, const void* src, size_t size);
-esp_err_t esp_partition_erase_range(const esp_partition_t* partition, size_t offset, size_t size);
-#endif
 #include "esp_vfs.h"
 #include "littlefs/lfs.h"
 #include "esp_littlefs.h"


### PR DESCRIPTION
Adds support for legacy projects pre-5.0.  Tested against v4.4.8 locally.

It is only the SDMMC APIs that depend on 5.0+.  There are recent changes to esp_littlefs that make using the latest version a desirable upgrade for older projects - in my case, the WDT servicing and access to fcntl(fd, F_GETPATH, …)