### PR TITLE
Add esp_blockdev support for ESP-IDF 6+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 3.16)
 file(GLOB SOURCES src/littlefs/*.c)
 list(APPEND SOURCES src/esp_littlefs.c src/littlefs_esp_part.c src/lfs_config.c)
 
+if(NOT IDF_TARGET STREQUAL "esp8266" AND "${IDF_VERSION_MAJOR}" VERSION_GREATER_EQUAL "6")
+    list(APPEND SOURCES src/littlefs_bdl.c)
+endif()
+
 if(IDF_TARGET STREQUAL "esp8266")
     # ESP8266 configuration here
 else()
@@ -15,6 +19,9 @@ else()
 endif()
 
 list(APPEND pub_requires esp_partition)
+if(NOT IDF_TARGET STREQUAL "esp8266" AND "${IDF_VERSION_MAJOR}" VERSION_GREATER_EQUAL "6")
+    list(APPEND pub_requires esp_blockdev)
+endif()
 list(APPEND priv_requires esptool_py spi_flash vfs)
 
 idf_component_register(

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -7,6 +7,14 @@
 #include <stdbool.h>
 #include "esp_partition.h"
 
+/** LittleFS over ESP-IDF Block Device Layer (`esp_blockdev`) is only built on ESP-IDF 6+ (non-ESP8266). */
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0) && !defined(ESP8266)
+#define ESP_LITTLEFS_HAS_BLOCKDEV 1
+#include "esp_blockdev.h"
+#else
+#define ESP_LITTLEFS_HAS_BLOCKDEV 0
+#endif
+
 #ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
 #include <sdmmc_cmd.h>
 #endif
@@ -34,12 +42,25 @@ extern "C" {
  */
 typedef struct {
     const char *base_path;            /**< Mounting point. */
-    const char *partition_label;      /**< Label of partition to use. If partition_label, partition, and sdcard are all NULL,
-                                           then the first partition with data subtype 'littlefs' will be used. */
+    const char *partition_label;      /**< Label of partition to use. If no mount source is set (partition_label,
+                                           partition, optional sdcard, optional blockdev on ESP-IDF 6+), the first data
+                                           partition with subtype 'littlefs' is used. */
     const esp_partition_t* partition; /**< partition to use if partition_label is NULL */
 
 #ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
     sdmmc_card_t *sdcard;       /**< SD card handle to use if both esp_partition handle & partition label is NULL */
+#endif
+
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+    /**
+     * Block device for LittleFS when partition_label, partition, and sdcard (when enabled) are not used.
+     * Use an `esp_blockdev` whose geometry matches the filesystem (read / program / erase sizes).
+     * For `esp_partition_ptr_get_blockdev()`, use an ESP-IDF build where partition BDL reports full geometry
+     * for read-only partitions (e.g. Espressif GitLab MR !45695).
+     * If the device provides `ops->release`, it is called when the filesystem is torn down
+     * (e.g. `esp_vfs_littlefs_unregister_blockdev`).
+     */
+    esp_blockdev_handle_t blockdev;
 #endif
 
     uint8_t format_if_mount_failed:1; /**< Format the file system if it fails to mount. */
@@ -97,6 +118,21 @@ esp_err_t esp_vfs_littlefs_unregister_sdmmc(sdmmc_card_t *sdcard);
  */
 esp_err_t esp_vfs_littlefs_unregister_partition(const esp_partition_t* partition);
 
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+/**
+ * Unregister and unmount littlefs from VFS.
+ *
+ * @param blockdev  blockdev to unregister.
+ *
+ * @return
+ *          - ESP_OK if successful
+ *          - ESP_ERR_INVALID_STATE already unregistered
+ *
+ * @note Invokes `blockdev->ops->release` when present; the handle must not be used afterward.
+ */
+esp_err_t esp_vfs_littlefs_unregister_blockdev(esp_blockdev_handle_t blockdev);
+#endif
+
 /**
  * Check if littlefs is mounted
  *
@@ -132,6 +168,19 @@ bool esp_littlefs_partition_mounted(const esp_partition_t* partition);
 bool esp_littlefs_sdmmc_mounted(sdmmc_card_t *sdcard);
 #endif
 
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+/**
+ * Check if littlefs is mounted
+ *
+ * @param blockdev  blockdev to check.
+ *
+ * @return  
+ *          - true    if mounted
+ *          - false   if not mounted
+ */
+bool esp_littlefs_blockdev_mounted(esp_blockdev_handle_t blockdev);
+#endif
+
 /**
  * Format the littlefs partition
  *
@@ -162,6 +211,18 @@ esp_err_t esp_littlefs_format_partition(const esp_partition_t* partition);
  *          - ESP_FAIL    on error
  */
 esp_err_t esp_littlefs_format_sdmmc(sdmmc_card_t *sdcard);
+#endif
+
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+/**
+ * Format the littlefs blockdev
+ *
+ * @param blockdev  blockdev to format.
+ * @return
+ *          - ESP_OK      if successful
+ *          - ESP_FAIL    on error
+ */
+esp_err_t esp_littlefs_format_blockdev(esp_blockdev_handle_t blockdev);
 #endif
 
 /**
@@ -203,6 +264,21 @@ esp_err_t esp_littlefs_partition_info(const esp_partition_t* partition, size_t *
  *          - ESP_ERR_INVALID_STATE   if not mounted
  */
 esp_err_t esp_littlefs_sdmmc_info(sdmmc_card_t *sdcard, size_t *total_bytes, size_t *used_bytes);
+#endif
+
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+/**
+ * Get information for littlefs
+ *
+ * @param blockdev                  the blockdev to get info for.
+ * @param[out] total_bytes          Size of the file system
+ * @param[out] used_bytes           Current used bytes in the file system
+ *
+ * @return  
+ *          - ESP_OK                  if success
+ *          - ESP_ERR_INVALID_STATE   if not mounted
+ */
+esp_err_t esp_littlefs_blockdev_info(esp_blockdev_handle_t blockdev, size_t *total_bytes, size_t *used_bytes);
 #endif
 
 #ifdef __cplusplus

--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -54,9 +54,14 @@ typedef struct {
 #if ESP_LITTLEFS_HAS_BLOCKDEV
     /**
      * Block device for LittleFS when partition_label, partition, and sdcard (when enabled) are not used.
-     * Use an `esp_blockdev` whose geometry matches the filesystem (read / program / erase sizes).
-     * For `esp_partition_ptr_get_blockdev()`, use an ESP-IDF build where partition BDL reports full geometry
-     * for read-only partitions (e.g. Espressif GitLab MR !45695).
+     *
+     * `device_flags` on the handle are validated at mount:
+     * - `encrypted` — mount fails (not supported).
+     * - `default_val_after_erase` — must be 1 (LittleFS expects 0xFF after erase).
+     * - `erase_before_write` and `and_type_write` are used only to select block sizing mode:
+     *   - classic mode (either flag set): `lfs` `block_size` uses geometry erase size.
+     *   - logical mode (both flags clear): `lfs` `block_size` uses lcm(read, prog).
+     *
      * If the device provides `ops->release`, it is called when the filesystem is torn down
      * (e.g. `esp_vfs_littlefs_unregister_blockdev`).
      */
@@ -218,6 +223,7 @@ esp_err_t esp_littlefs_format_sdmmc(sdmmc_card_t *sdcard);
  * Format the littlefs blockdev
  *
  * @param blockdev  blockdev to format.
+ * @note This call does not transfer ownership and does not invoke `blockdev->ops->release`.
  * @return
  *          - ESP_OK      if successful
  *          - ESP_FAIL    on error

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -1091,26 +1091,44 @@ static esp_err_t esp_littlefs_init_sdcard(esp_littlefs_t** efs, sdmmc_card_t* sd
 #endif // CONFIG_LITTLEFS_SDMMC_SUPPORT
 
 #if ESP_LITTLEFS_HAS_BLOCKDEV
+static size_t gcd(size_t a, size_t b)
+{
+    while (b) {
+        size_t t = b;
+        b = a % b;
+        a = t;
+    }
+    return a;
+}
+
 /**
  * LittleFS requires cache_size % read_size == 0, cache_size % prog_size == 0, and block_size % cache_size == 0.
  *
  * Each open file uses vfs_littlefs_file_t::lfs_buffer[CONFIG_LITTLEFS_CACHE_SIZE] for lfs_file_config.buffer,
  * so cfg.cache_size must never exceed CONFIG_LITTLEFS_CACHE_SIZE (otherwise the VFS corrupts adjacent fields).
+ *
+ * Callers must ensure block_sz % read_sz == 0 and block_sz % prog_sz == 0.
  */
 static size_t esp_littlefs_bdl_pick_cache_size(size_t block_sz, size_t read_sz, size_t prog_sz)
 {
+    size_t unit = read_sz / gcd(read_sz, prog_sz) * prog_sz; /* lcm(read_sz, prog_sz) */
+
     size_t max_cache = CONFIG_LITTLEFS_CACHE_SIZE;
     if (max_cache > block_sz) {
         max_cache = block_sz;
     }
-    for (size_t c = max_cache; c > 0; --c) {
-        if (block_sz % c == 0 && c % read_sz == 0 && c % prog_sz == 0) {
-            return c;
-        }
+
+    /* Round max_cache down to the nearest multiple of unit.
+     * Because callers guarantee block_sz % unit == 0, any multiple of unit
+     * that is <= block_sz will also divide block_sz. */
+    size_t c = (max_cache / unit) * unit;
+    assert(c == 0 || block_sz % c == 0);
+
+    if (c == 0) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "No valid cache_size <= %u for block=%u read=%u prog=%u",
+                 (unsigned)max_cache, (unsigned)block_sz, (unsigned)read_sz, (unsigned)prog_sz);
     }
-    ESP_LOGE(ESP_LITTLEFS_TAG, "No valid cache_size <= %u for block=%u read=%u prog=%u",
-             (unsigned)max_cache, (unsigned)block_sz, (unsigned)read_sz, (unsigned)prog_sz);
-    return 0;
+    return c;
 }
 
 static esp_err_t esp_littlefs_init_blockdev(esp_littlefs_t** efs, esp_blockdev_handle_t blockdev, bool read_only)
@@ -1190,8 +1208,6 @@ static esp_err_t esp_littlefs_init_blockdev(esp_littlefs_t** efs, esp_blockdev_h
         }
         (*efs)->cfg.cache_size = esp_littlefs_bdl_pick_cache_size(erase_size, read_size, write_size);
         if ((*efs)->cfg.cache_size == 0) {
-            free(*efs);
-            *efs = NULL;
             return ESP_ERR_INVALID_ARG;
         }
         (*efs)->cfg.lookahead_size = CONFIG_LITTLEFS_LOOKAHEAD_SIZE;

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -1363,7 +1363,6 @@ static esp_err_t esp_littlefs_init(const esp_vfs_littlefs_conf_t* conf, int *ind
             ESP_LOGE(ESP_LITTLEFS_TAG, "Failed when checking SD card status: 0x%x", err);
             goto exit;
         }
-    }
 #endif
 #if ESP_LITTLEFS_HAS_BLOCKDEV
     } else if (conf->blockdev) {
@@ -1372,13 +1371,8 @@ static esp_err_t esp_littlefs_init(const esp_vfs_littlefs_conf_t* conf, int *ind
             err = ESP_ERR_INVALID_STATE;
             goto exit;
         }
-    }
 #endif
-#if defined(CONFIG_LITTLEFS_SDMMC_SUPPORT) || ESP_LITTLEFS_HAS_BLOCKDEV
-    else {
-#else
     } else {
-#endif
         // Find first partition with "littlefs" subtype.
         partition = esp_partition_find_first(
                 ESP_PARTITION_TYPE_DATA,

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -1472,11 +1472,10 @@ static esp_err_t esp_littlefs_init(const esp_vfs_littlefs_conf_t* conf, int *ind
 
 exit:
     if(err != ESP_OK){
+        esp_littlefs_free(&efs);
+        /* efs may or may not have been published to _efs[*index]; clear it either way. */
         if( *index >= 0 ) {
-            esp_littlefs_free(&_efs[*index]);
-        }
-        else{
-            esp_littlefs_free(&efs);
+            _efs[*index] = NULL;
         }
     }
     xSemaphoreGive(_efs_lock);

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -706,7 +706,11 @@ esp_err_t esp_littlefs_format_blockdev(esp_blockdev_handle_t blockdev)
     err = format_from_efs(_efs[index]);
 
 exit:
-    if (efs_free && index>=0) esp_littlefs_free(&_efs[index]);
+    if (efs_free && index >= 0 && _efs[index]) {
+        /* Formatting through a temporary EFS context must not consume caller-owned handles. */
+        _efs[index]->bdl_handle = NULL;
+        esp_littlefs_free(&_efs[index]);
+    }
     return err;
 }
 #endif
@@ -1101,6 +1105,14 @@ static size_t gcd(size_t a, size_t b)
     return a;
 }
 
+static size_t lcm_size(size_t a, size_t b)
+{
+    if (a == 0 || b == 0) {
+        return 0;
+    }
+    return a / gcd(a, b) * b;
+}
+
 /**
  * LittleFS requires cache_size % read_size == 0, cache_size % prog_size == 0, and block_size % cache_size == 0.
  *
@@ -1133,6 +1145,43 @@ static size_t esp_littlefs_bdl_pick_cache_size(size_t block_sz, size_t read_sz, 
 
 static esp_err_t esp_littlefs_init_blockdev(esp_littlefs_t** efs, esp_blockdev_handle_t blockdev, bool read_only)
 {
+    const esp_blockdev_flags_t *f = &blockdev->device_flags;
+    const esp_blockdev_ops_t *ops = blockdev->ops;
+
+    if (!ops || !ops->read) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL device must provide read operation");
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    if (f->encrypted) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL encrypted block devices are not supported");
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    /* LittleFS assumes erased storage reads as 0xFF (all bits 1). */
+    if (!f->default_val_after_erase) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL requires default_val_after_erase=1 (0xFF erased state)");
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    /*
+     * Use BDL flags only to determine effective LittleFS block sizing mode:
+     * - classic: any erase-dependent/program-constrained medium
+     * - logical: neither erase_before_write nor and_type_write are set
+     */
+    const bool classic = f->erase_before_write || f->and_type_write;
+    const bool logical = !classic;
+
+    if (!read_only && blockdev->device_flags.read_only) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Refusing to mount read-only block dev for write");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!read_only && (!ops->write || !ops->erase)) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Writable LittleFS mount requires BDL write and erase operations");
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
     /* Allocate Context */
     *efs = esp_littlefs_calloc(1, sizeof(esp_littlefs_t));
     if (*efs == NULL) {
@@ -1141,6 +1190,7 @@ static esp_err_t esp_littlefs_init_blockdev(esp_littlefs_t** efs, esp_blockdev_h
     }
 
     (*efs)->bdl_handle = blockdev;
+    (*efs)->bdl_logical_block_mode = logical;
 
     const esp_blockdev_geometry_t *g = &blockdev->geometry;
     if (g->read_size == 0 || g->disk_size == 0) {
@@ -1149,15 +1199,15 @@ static esp_err_t esp_littlefs_init_blockdev(esp_littlefs_t** efs, esp_blockdev_h
         return ESP_ERR_INVALID_ARG;
     }
 
-    if (!read_only && blockdev->device_flags.read_only) {
-        ESP_LOGE(ESP_LITTLEFS_TAG, "Refusing to mount read-only block dev for write");
+    /* Classic (erase_before_write): non-zero program and erase units; partition BDL reports them for read-only media too. */
+    if (classic && (g->erase_size == 0 || g->write_size == 0)) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Invalid blockdev geometry (write_size=%u erase_size=%u)",
+                 (unsigned)g->write_size, (unsigned)g->erase_size);
         return ESP_ERR_INVALID_ARG;
     }
 
-    /* LittleFS needs non-zero program and erase units; partition BDL reports them for read-only media too. */
-    if (g->erase_size == 0 || g->write_size == 0) {
-        ESP_LOGE(ESP_LITTLEFS_TAG, "Invalid blockdev geometry (write_size=%u erase_size=%u)",
-                 (unsigned)g->write_size, (unsigned)g->erase_size);
+    if (logical && g->write_size == 0) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Invalid blockdev geometry for logical BDL mode (write_size=0)");
         return ESP_ERR_INVALID_ARG;
     }
 
@@ -1169,10 +1219,23 @@ static esp_err_t esp_littlefs_init_blockdev(esp_littlefs_t** efs, esp_blockdev_h
             (g->recommended_write_size > 0 && g->recommended_write_size % g->write_size == 0)
                     ? g->recommended_write_size
                     : g->write_size;
-    size_t erase_size =
-            (g->recommended_erase_size > 0 && g->recommended_erase_size % g->erase_size == 0)
-                    ? g->recommended_erase_size
-                    : g->erase_size;
+
+    size_t erase_size;
+    if (classic) {
+        erase_size =
+                (g->recommended_erase_size > 0 && g->recommended_erase_size % g->erase_size == 0)
+                        ? g->recommended_erase_size
+                        : g->erase_size;
+    } else {
+        /* Logical block size: lcm(read, prog); ignore huge physical erase_size for LFS block boundaries. */
+        erase_size = lcm_size(read_size, write_size);
+        if (erase_size == 0 || (g->disk_size % erase_size) != 0) {
+            ESP_LOGE(ESP_LITTLEFS_TAG,
+                     "Logical BDL: disk_size (%" PRIu64 ") must be a non-zero multiple of lcm(read_size=%u, prog_size=%u) (%u)",
+                     (uint64_t)g->disk_size, (unsigned)read_size, (unsigned)write_size, (unsigned)erase_size);
+            return ESP_ERR_INVALID_ARG;
+        }
+    }
 
     if (read_size > erase_size || write_size > erase_size) {
         ESP_LOGE(ESP_LITTLEFS_TAG, "read_size (%u) and prog_size (%u) must not exceed block_size (%u)",
@@ -1181,7 +1244,7 @@ static esp_err_t esp_littlefs_init_blockdev(esp_littlefs_t** efs, esp_blockdev_h
     }
 
     if (erase_size % read_size != 0 || erase_size % write_size != 0) {
-        ESP_LOGE(ESP_LITTLEFS_TAG, "erase_size (%u) must be a multiple of read_size (%u) and prog_size (%u)",
+        ESP_LOGE(ESP_LITTLEFS_TAG, "block_size (%u) must be a multiple of read_size (%u) and prog_size (%u)",
                  (unsigned)erase_size, (unsigned)read_size, (unsigned)write_size);
         return ESP_ERR_INVALID_ARG;
     }
@@ -1482,10 +1545,14 @@ static esp_err_t esp_littlefs_init(const esp_vfs_littlefs_conf_t* conf, int *ind
 
 exit:
     if(err != ESP_OK){
-        esp_littlefs_free(&efs);
-        /* efs may or may not have been published to _efs[*index]; clear it either way. */
-        if( *index >= 0 ) {
-            _efs[*index] = NULL;
+        /*
+         * Only tear down _efs[*index] when this call published the same context there.
+         * Otherwise, leave pre-existing mounts untouched (e.g. duplicate-register checks).
+         */
+        if (*index >= 0 && _efs[*index] == efs) {
+            esp_littlefs_free(&_efs[*index]);
+        } else {
+            esp_littlefs_free(&efs);
         }
     }
     xSemaphoreGive(_efs_lock);

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -17,6 +17,7 @@
 #include "freertos/semphr.h"
 #include "freertos/task.h"
 #include "littlefs_api.h"
+#include <inttypes.h>
 #include <dirent.h>
 #include <sys/dirent.h>
 #include <sys/errno.h>
@@ -117,6 +118,9 @@ static esp_err_t esp_littlefs_init(const esp_vfs_littlefs_conf_t* conf, int *ind
 
 static esp_err_t esp_littlefs_by_label(const char* label, int * index);
 static esp_err_t esp_littlefs_by_partition(const esp_partition_t* part, int*index);
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+static esp_err_t esp_littlefs_by_blockdev(esp_blockdev_handle_t blockdev, int * index);
+#endif
 static int esp_littlefs_file_sync(esp_littlefs_t *efs, vfs_littlefs_file_t *file);
 
 #ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
@@ -126,6 +130,9 @@ static esp_err_t esp_littlefs_by_sdmmc_handle(sdmmc_card_t *handle, int *index);
 static esp_err_t esp_littlefs_get_empty(int *index);
 static void      esp_littlefs_free(esp_littlefs_t ** efs);
 static int       esp_littlefs_flags_conv(int m);
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+static esp_err_t esp_littlefs_init_blockdev(esp_littlefs_t** efs, esp_blockdev_handle_t blockdev, bool read_only);
+#endif
 
 #if CONFIG_LITTLEFS_USE_MTIME
 static int       vfs_littlefs_utime(void *ctx, const char *path, const struct utimbuf *times);
@@ -254,6 +261,13 @@ esp_err_t format_from_efs(esp_littlefs_t *efs)
             res = lfs_format(efs->fs, &efs->cfg);
         } else
 #endif
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+        if (efs->bdl_handle) {
+            const esp_blockdev_geometry_t *g = &efs->bdl_handle->geometry;
+            efs->cfg.block_count = g->disk_size ? g->disk_size / efs->cfg.block_size : efs->cfg.block_count;
+            res = lfs_format(efs->fs, &efs->cfg);
+        } else
+#endif
         {
             efs->cfg.block_count = efs->partition->size / efs->cfg.block_size;
             res = lfs_format(efs->fs, &efs->cfg);
@@ -328,6 +342,17 @@ bool esp_littlefs_sdmmc_mounted(sdmmc_card_t *sdcard)
 }
 #endif
 
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+bool esp_littlefs_blockdev_mounted(esp_blockdev_handle_t blockdev)
+{
+    int index;
+    esp_err_t err = esp_littlefs_by_blockdev(blockdev, &index);
+
+    if (err != ESP_OK) return false;
+    return _efs[index]->cache_size > 0;
+}
+#endif
+
 esp_err_t esp_littlefs_info(const char* partition_label, size_t *total_bytes, size_t *used_bytes){
     int index;
     esp_err_t err;
@@ -358,6 +383,20 @@ esp_err_t esp_littlefs_sdmmc_info(sdmmc_card_t *sdcard, size_t *total_bytes, siz
 
     err = esp_littlefs_by_sdmmc_handle(sdcard, &index);
     if(err != ESP_OK) return err;
+    get_total_and_used_bytes(_efs[index], total_bytes, used_bytes);
+
+    return ESP_OK;
+}
+#endif
+
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+esp_err_t esp_littlefs_blockdev_info(esp_blockdev_handle_t blockdev, size_t *total_bytes, size_t *used_bytes)
+{
+    int index;
+    esp_err_t err;
+
+    err = esp_littlefs_by_blockdev(blockdev, &index);
+    if (err != ESP_OK) return err;
     get_total_and_used_bytes(_efs[index], total_bytes, used_bytes);
 
     return ESP_OK;
@@ -503,6 +542,28 @@ esp_err_t esp_vfs_littlefs_unregister_partition(const esp_partition_t* partition
     return ESP_OK;
 }
 
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+esp_err_t esp_vfs_littlefs_unregister_blockdev(esp_blockdev_handle_t blockdev)
+{
+    assert(blockdev);
+    int index;
+    if (esp_littlefs_by_blockdev(blockdev, &index) != ESP_OK) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Blockdev was never registered.");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    ESP_LOGV(ESP_LITTLEFS_TAG, "Unregistering blockdev %p", blockdev);
+    esp_err_t err = esp_vfs_unregister(_efs[index]->base_path);
+    if (err != ESP_OK) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Failed to unregister blockdev %p", blockdev);
+        return err;
+    }
+    esp_littlefs_free(&_efs[index]);
+    _efs[index] = NULL;
+    return ESP_OK;
+}
+#endif
+
 esp_err_t esp_littlefs_format(const char* partition_label) {
     bool efs_free = false;
     int index = -1;
@@ -609,6 +670,43 @@ esp_err_t esp_littlefs_format_sdmmc(sdmmc_card_t *sdcard)
 
 exit:
     if(efs_free && index>=0) esp_littlefs_free(&_efs[index]);
+    return err;
+}
+#endif
+
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+esp_err_t esp_littlefs_format_blockdev(esp_blockdev_handle_t blockdev)
+{
+    assert(blockdev);
+
+    bool efs_free = false;
+    int index = -1;
+    esp_err_t err;
+
+    ESP_LOGV(ESP_LITTLEFS_TAG, "Formatting blockdev %p", blockdev);
+
+    /* Get a context */
+    err = esp_littlefs_by_blockdev(blockdev, &index);
+
+    if (err != ESP_OK) {
+        /* Create a tmp context */
+        ESP_LOGV(ESP_LITTLEFS_TAG, "Temporarily creating EFS context.");
+        efs_free = true;
+        const esp_vfs_littlefs_conf_t conf = {
+                .dont_mount = true,
+                .blockdev = blockdev,
+        };
+        err = esp_littlefs_init(&conf, &index);
+        if (err != ESP_OK) {
+            ESP_LOGE(ESP_LITTLEFS_TAG, "Failed to initialize to format.");
+            goto exit;
+        }
+    }
+
+    err = format_from_efs(_efs[index]);
+
+exit:
+    if (efs_free && index>=0) esp_littlefs_free(&_efs[index]);
     return err;
 }
 #endif
@@ -726,6 +824,14 @@ static void esp_littlefs_free(esp_littlefs_t ** efs)
     esp_partition_munmap(e->mmap_handle);
 #endif
 
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+    /* optionally release blockdev metadata */
+    if (e->bdl_handle && e->bdl_handle->ops && e->bdl_handle->ops->release) {
+        e->bdl_handle->ops->release(e->bdl_handle);
+        e->bdl_handle = NULL;
+    }
+#endif
+
     esp_littlefs_free_fds(e);
     free(e);
 }
@@ -831,6 +937,34 @@ static esp_err_t esp_littlefs_by_sdmmc_handle(sdmmc_card_t *handle, int *index)
     }
 
     ESP_LOGV(ESP_LITTLEFS_TAG, "Existing filesystem %p not found", handle);
+    return ESP_ERR_NOT_FOUND;
+}
+#endif
+
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+/**
+ * Get a mounted littlefs filesystem by blockdev.
+ * @param[in] label
+ * @param[out] index index into _efs
+ * @return ESP_OK on success
+ */
+static esp_err_t esp_littlefs_by_blockdev(esp_blockdev_handle_t blockdev, int * index){
+    if(!blockdev || !index) return ESP_ERR_INVALID_ARG;
+
+    ESP_LOGV(ESP_LITTLEFS_TAG, "Searching for existing filesystem for blockdev %p", blockdev);
+
+    for (int i = 0; i < CONFIG_LITTLEFS_MAX_PARTITIONS; i++) {
+        esp_littlefs_t *p = _efs[i];
+        if (!p) continue;
+        if (!p->bdl_handle) continue;
+        if (p->bdl_handle == blockdev) {
+            *index = i;
+            ESP_LOGV(ESP_LITTLEFS_TAG, "Found existing filesystem %p at index %d", blockdev, *index);
+            return ESP_OK;
+        }
+    }
+
+    ESP_LOGV(ESP_LITTLEFS_TAG, "Existing filesystem %p not found", blockdev);
     return ESP_ERR_NOT_FOUND;
 }
 #endif
@@ -956,6 +1090,141 @@ static esp_err_t esp_littlefs_init_sdcard(esp_littlefs_t** efs, sdmmc_card_t* sd
 }
 #endif // CONFIG_LITTLEFS_SDMMC_SUPPORT
 
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+/**
+ * LittleFS requires cache_size % read_size == 0, cache_size % prog_size == 0, and block_size % cache_size == 0.
+ *
+ * Each open file uses vfs_littlefs_file_t::lfs_buffer[CONFIG_LITTLEFS_CACHE_SIZE] for lfs_file_config.buffer,
+ * so cfg.cache_size must never exceed CONFIG_LITTLEFS_CACHE_SIZE (otherwise the VFS corrupts adjacent fields).
+ */
+static size_t esp_littlefs_bdl_pick_cache_size(size_t block_sz, size_t read_sz, size_t prog_sz)
+{
+    size_t max_cache = CONFIG_LITTLEFS_CACHE_SIZE;
+    if (max_cache > block_sz) {
+        max_cache = block_sz;
+    }
+    for (size_t c = max_cache; c > 0; --c) {
+        if (block_sz % c == 0 && c % read_sz == 0 && c % prog_sz == 0) {
+            return c;
+        }
+    }
+    ESP_LOGE(ESP_LITTLEFS_TAG, "No valid cache_size <= %u for block=%u read=%u prog=%u",
+             (unsigned)max_cache, (unsigned)block_sz, (unsigned)read_sz, (unsigned)prog_sz);
+    return 0;
+}
+
+static esp_err_t esp_littlefs_init_blockdev(esp_littlefs_t** efs, esp_blockdev_handle_t blockdev, bool read_only)
+{
+    /* Allocate Context */
+    *efs = esp_littlefs_calloc(1, sizeof(esp_littlefs_t));
+    if (*efs == NULL) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "esp_littlefs could not be malloced");
+        return ESP_ERR_NO_MEM;
+    }
+
+    (*efs)->bdl_handle = blockdev;
+
+    const esp_blockdev_geometry_t *g = &blockdev->geometry;
+    if (g->read_size == 0 || g->disk_size == 0) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Invalid blockdev geometry (read_size=%u disk_size=%" PRIu64 ")",
+                 (unsigned)g->read_size, (uint64_t)g->disk_size);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!read_only && blockdev->device_flags.read_only) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Refusing to mount read-only block dev for write");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* LittleFS needs non-zero program and erase units; partition BDL reports them for read-only media too. */
+    if (g->erase_size == 0 || g->write_size == 0) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Invalid blockdev geometry (write_size=%u erase_size=%u)",
+                 (unsigned)g->write_size, (unsigned)g->erase_size);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    size_t read_size =
+            (g->recommended_read_size > 0 && g->recommended_read_size % g->read_size == 0)
+                    ? g->recommended_read_size
+                    : g->read_size;
+    size_t write_size =
+            (g->recommended_write_size > 0 && g->recommended_write_size % g->write_size == 0)
+                    ? g->recommended_write_size
+                    : g->write_size;
+    size_t erase_size =
+            (g->recommended_erase_size > 0 && g->recommended_erase_size % g->erase_size == 0)
+                    ? g->recommended_erase_size
+                    : g->erase_size;
+
+    if (read_size > erase_size || write_size > erase_size) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "read_size (%u) and prog_size (%u) must not exceed block_size (%u)",
+                 (unsigned)read_size, (unsigned)write_size, (unsigned)erase_size);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (erase_size % read_size != 0 || erase_size % write_size != 0) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "erase_size (%u) must be a multiple of read_size (%u) and prog_size (%u)",
+                 (unsigned)erase_size, (unsigned)read_size, (unsigned)write_size);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    { /* LittleFS Configuration */
+        (*efs)->cfg.context = *efs;
+        (*efs)->read_only = read_only;
+
+        // block device operations
+        (*efs)->cfg.read  = littlefs_bdl_read;
+        (*efs)->cfg.prog  = littlefs_bdl_write;
+        (*efs)->cfg.erase = littlefs_bdl_erase;
+        (*efs)->cfg.sync  = littlefs_bdl_sync;
+
+        // block device configuration
+        (*efs)->cfg.read_size = read_size;
+        (*efs)->cfg.prog_size = write_size;
+        (*efs)->cfg.block_size = erase_size;
+        (*efs)->cfg.block_count = g->disk_size / (*efs)->cfg.block_size;
+        if ((*efs)->cfg.block_count == 0) {
+            ESP_LOGE(ESP_LITTLEFS_TAG, "Invalid blockdev geometry: block_count=0 (disk_size=%" PRIu64 ", block_size=%u)",
+                     (uint64_t)g->disk_size, (unsigned)(*efs)->cfg.block_size);
+            return ESP_ERR_INVALID_ARG;
+        }
+        (*efs)->cfg.cache_size = esp_littlefs_bdl_pick_cache_size(erase_size, read_size, write_size);
+        if ((*efs)->cfg.cache_size == 0) {
+            free(*efs);
+            *efs = NULL;
+            return ESP_ERR_INVALID_ARG;
+        }
+        (*efs)->cfg.lookahead_size = CONFIG_LITTLEFS_LOOKAHEAD_SIZE;
+        (*efs)->cfg.block_cycles = CONFIG_LITTLEFS_BLOCK_CYCLES;
+#if CONFIG_LITTLEFS_MULTIVERSION
+#if CONFIG_LITTLEFS_DISK_VERSION_MOST_RECENT
+        (*efs)->cfg.disk_version = 0;
+#elif CONFIG_LITTLEFS_DISK_VERSION_2_1
+        (*efs)->cfg.disk_version = 0x00020001;
+#elif CONFIG_LITTLEFS_DISK_VERSION_2_0
+        (*efs)->cfg.disk_version = 0x00020000;
+#else
+#error "CONFIG_LITTLEFS_MULTIVERSION enabled but no or unknown disk version selected!"
+#endif
+#endif
+    }
+
+    (*efs)->lock = xSemaphoreCreateRecursiveMutex();
+    if ((*efs)->lock == NULL) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "mutex lock could not be created");
+        return ESP_ERR_NO_MEM;
+    }
+
+    (*efs)->fs = esp_littlefs_calloc(1, sizeof(lfs_t));
+    if ((*efs)->fs == NULL) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "littlefs could not be malloced");
+        return ESP_ERR_NO_MEM;
+    }
+
+    return ESP_OK;
+}
+#endif /* ESP_LITTLEFS_HAS_BLOCKDEV */
+
 static esp_err_t esp_littlefs_init_efs(esp_littlefs_t** efs, const esp_partition_t* partition, bool read_only)
 {
     /* Allocate Context */
@@ -1078,8 +1347,22 @@ static esp_err_t esp_littlefs_init(const esp_vfs_littlefs_conf_t* conf, int *ind
             ESP_LOGE(ESP_LITTLEFS_TAG, "Failed when checking SD card status: 0x%x", err);
             goto exit;
         }
+    }
 #endif
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+    } else if (conf->blockdev) {
+        if (esp_littlefs_by_blockdev(conf->blockdev, index) == ESP_OK) {
+            ESP_LOGE(ESP_LITTLEFS_TAG, "Blockdev already used");
+            err = ESP_ERR_INVALID_STATE;
+            goto exit;
+        }
+    }
+#endif
+#if defined(CONFIG_LITTLEFS_SDMMC_SUPPORT) || ESP_LITTLEFS_HAS_BLOCKDEV
+    else {
+#else
     } else {
+#endif
         // Find first partition with "littlefs" subtype.
         partition = esp_partition_find_first(
                 ESP_PARTITION_TYPE_DATA,
@@ -1097,6 +1380,14 @@ static esp_err_t esp_littlefs_init(const esp_vfs_littlefs_conf_t* conf, int *ind
 	if (conf->sdcard) {
         err = esp_littlefs_init_sdcard(&efs, conf->sdcard, conf->read_only);
         if(err != ESP_OK) {
+            goto exit;
+        }
+    } else
+#endif
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+    if (conf->blockdev) {
+        err = esp_littlefs_init_blockdev(&efs, conf->blockdev, conf->read_only);
+        if (err != ESP_OK) {
             goto exit;
         }
     } else
@@ -1132,6 +1423,11 @@ static esp_err_t esp_littlefs_init(const esp_vfs_littlefs_conf_t* conf, int *ind
                 err = esp_littlefs_format_sdmmc(conf->sdcard);
             } else
 #endif
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+            if (conf->blockdev) {
+                err = esp_littlefs_format_blockdev(conf->blockdev);
+            } else
+#endif
             {
                 err = esp_littlefs_format_partition(efs->partition);
             }
@@ -1154,6 +1450,11 @@ static esp_err_t esp_littlefs_init(const esp_vfs_littlefs_conf_t* conf, int *ind
 #ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
             if (efs->sdcard) {
                 res = lfs_fs_grow(efs->fs, efs->sdcard->csd.capacity);
+            } else
+#endif
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+            if (efs->bdl_handle) {
+                res = lfs_fs_grow(efs->fs, efs->cfg.block_count);
             } else
 #endif
             {

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -944,7 +944,7 @@ static esp_err_t esp_littlefs_by_sdmmc_handle(sdmmc_card_t *handle, int *index)
 #if ESP_LITTLEFS_HAS_BLOCKDEV
 /**
  * Get a mounted littlefs filesystem by blockdev.
- * @param[in] label
+ * @param[in] blockdev
  * @param[out] index index into _efs
  * @return ESP_OK on success
  */

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -67,6 +67,8 @@ typedef struct {
     lfs_t *fs;                                /*!< Handle to the underlying littlefs */
     SemaphoreHandle_t lock;                   /*!< FS lock */
 
+    // TODO(next major release): partition, sdcard, and bdl_handle are mutually exclusive
+    // and should be refactored into a union with a backend_type discriminator.
 #ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
     sdmmc_card_t *sdcard;                     /*!< The SD card driver handle on which littlefs is located */
 #endif

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -8,6 +8,7 @@
 #include "freertos/semphr.h"
 #include "esp_vfs.h"
 #include "esp_partition.h"
+#include "esp_littlefs.h"
 #include "littlefs/lfs.h"
 #include "sdkconfig.h"
 
@@ -71,6 +72,9 @@ typedef struct {
 #endif
 
     const esp_partition_t* partition;         /*!< The partition on which littlefs is located */
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+    esp_blockdev_handle_t  bdl_handle;          /*!< Optional block device layer handle backing LittleFS */
+#endif
 
 #ifdef CONFIG_LITTLEFS_MMAP_PARTITION
     const void *mmap_data;                    /*!< Buffer of mmapped partition */
@@ -142,6 +146,61 @@ int littlefs_esp_part_erase(const struct lfs_config *c, lfs_block_t block);
  * @return errorcode. 0 on success.
  */
 int littlefs_esp_part_sync(const struct lfs_config *c);
+
+#if ESP_LITTLEFS_HAS_BLOCKDEV
+
+/**
+ * @brief Read a region in a block via esp_blockdev.
+ *
+ * Negative error codes are propagated to the user.
+ *
+ * Expects `c->context` to point to an initialized `esp_littlefs_t` with `bdl_handle` set.
+ *
+ * @return errorcode. 0 on success.
+ */
+int littlefs_bdl_read(const struct lfs_config *c, lfs_block_t block,
+                      lfs_off_t off, void *buffer, lfs_size_t size);
+
+/**
+ * @brief Program a region in a block via esp_blockdev.
+ *
+ * The block must have previously been erased.
+ * Negative error codes are propagated to the user.
+ * May return LFS_ERR_CORRUPT if the block should be considered bad.
+ *
+ * Expects `c->context` to point to an initialized `esp_littlefs_t` with `bdl_handle` set.
+ *
+ * @return errorcode. 0 on success.
+ */
+int littlefs_bdl_write(const struct lfs_config *c, lfs_block_t block,
+                       lfs_off_t off, const void *buffer, lfs_size_t size);
+
+/**
+ * @brief Erase a block via esp_blockdev.
+ *
+ * A block must be erased before being programmed.
+ * The state of an erased block is undefined.
+ * Negative error codes are propagated to the user.
+ * May return LFS_ERR_CORRUPT if the block should be considered bad.
+ *
+ * Expects `c->context` to point to an initialized `esp_littlefs_t` with `bdl_handle` set.
+ *
+ * @return errorcode. 0 on success.
+ */
+int littlefs_bdl_erase(const struct lfs_config *c, lfs_block_t block);
+
+/**
+ * @brief Sync the state of the underlying block device via esp_blockdev.
+ *
+ * Negative error codes are propagated to the user.
+ *
+ * Expects `c->context` to point to an initialized `esp_littlefs_t` with `bdl_handle` set.
+ *
+ * @return errorcode. 0 on success.
+ */
+int littlefs_bdl_sync(const struct lfs_config *c);
+
+#endif /* ESP_LITTLEFS_HAS_BLOCKDEV */
 
 #ifdef CONFIG_LITTLEFS_SDMMC_SUPPORT
 

--- a/src/littlefs_api.h
+++ b/src/littlefs_api.h
@@ -76,6 +76,9 @@ typedef struct {
     const esp_partition_t* partition;         /*!< The partition on which littlefs is located */
 #if ESP_LITTLEFS_HAS_BLOCKDEV
     esp_blockdev_handle_t  bdl_handle;          /*!< Optional block device layer handle backing LittleFS */
+    /** When true, BDL \c erase_before_write is false: LittleFS \c block_size is derived from read/program sizes
+     *  (not geometry \c erase_size). Physical erase alignment is not enforced in this path. */
+    bool                   bdl_logical_block_mode;
 #endif
 
 #ifdef CONFIG_LITTLEFS_MMAP_PARTITION

--- a/src/littlefs_bdl.c
+++ b/src/littlefs_bdl.c
@@ -132,24 +132,39 @@ int littlefs_bdl_erase(const struct lfs_config *c, lfs_block_t block)
 {
     esp_littlefs_t *efs = (esp_littlefs_t *)c->context;
     esp_blockdev_handle_t dev = efs ? efs->bdl_handle : NULL;
-    if (!validate_handle(dev, "erase") || !dev->ops->erase) {
+    if (!validate_handle(dev, "erase")) {
         return LFS_ERR_IO;
     }
 
-    if ((efs && efs->read_only) || dev->device_flags.read_only || dev->geometry.erase_size == 0) {
-        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL erase not supported (read-only or erase_size=0)");
+    if ((efs && efs->read_only) || dev->device_flags.read_only) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL erase not supported (read-only)");
         return LFS_ERR_IO;
     }
 
     const uint64_t addr = (uint64_t)block * c->block_size;
     const size_t erase_len = c->block_size;
+    const bool logical = efs && efs->bdl_logical_block_mode;
+
+    /*
+     * Logical BDL mode (erase_before_write=0): LittleFS block_size may be smaller than geometry.erase_size.
+     * Skip alignment to geometry.erase_size; erase operation is still required for LittleFS compatibility.
+     */
+    if (!dev->ops->erase) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL erase not supported (missing erase op)");
+        return LFS_ERR_IO;
+    }
+
+    if (!logical && dev->geometry.erase_size == 0) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL erase not supported (erase_size=0)");
+        return LFS_ERR_IO;
+    }
 
 #ifdef CONFIG_LITTLEFS_WDT_RESET
     esp_task_wdt_reset();
 #endif
 
-    /* Basic alignment check against device geometry if provided */
-    if (dev->geometry.erase_size &&
+    /* Classic (erase_before_write=1): logical blocks align to geometry.erase_size. */
+    if (!logical && dev->geometry.erase_size &&
         ((addr % dev->geometry.erase_size) || (erase_len % dev->geometry.erase_size))) {
         ESP_LOGE(ESP_LITTLEFS_TAG, "BDL erase misaligned: addr=0x%016" PRIx64 ", len=0x%08x, erase_size=0x%08x",
                  addr, (unsigned)erase_len, (unsigned)dev->geometry.erase_size);

--- a/src/littlefs_bdl.c
+++ b/src/littlefs_bdl.c
@@ -1,0 +1,193 @@
+/**
+ * @file littlefs_bdl.c
+ * @brief Maps the ESP-IDF Block Device Layer (BDL) <-> littlefs HAL
+ */
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "esp_err.h"
+#include "esp_log.h"
+#include "esp_blockdev.h"
+#include "littlefs/lfs.h"
+#include "littlefs_api.h"
+
+#ifdef CONFIG_LITTLEFS_WDT_RESET
+#include "esp_task_wdt.h"
+#endif
+
+/* Convert esp_err_t to the nearest littlefs error code */
+static int esp_err_to_lfs(esp_err_t err)
+{
+    switch (err) {
+    case ESP_OK:
+        return LFS_ERR_OK;
+    case ESP_ERR_NO_MEM:
+        return LFS_ERR_NOMEM;
+    case ESP_ERR_INVALID_ARG:
+    case ESP_ERR_INVALID_SIZE:
+    case ESP_ERR_INVALID_STATE:
+        return LFS_ERR_INVAL;
+    case ESP_ERR_NOT_FOUND:
+    case ESP_ERR_NOT_SUPPORTED:
+        return LFS_ERR_IO;
+    default:
+        return LFS_ERR_IO;
+    }
+}
+
+static bool validate_handle(const esp_blockdev_handle_t dev, const char *op)
+{
+    if (!dev) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL %s called with null device handle", op);
+        return false;
+    }
+
+    if (!dev->ops) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL %s called with missing ops table", op);
+        return false;
+    }
+
+    return true;
+}
+
+int littlefs_bdl_read(const struct lfs_config *c, lfs_block_t block,
+                      lfs_off_t off, void *buffer, lfs_size_t size)
+{
+    esp_littlefs_t *efs = (esp_littlefs_t *)c->context;
+    esp_blockdev_handle_t dev = efs ? efs->bdl_handle : NULL;
+    if (!validate_handle(dev, "read") || !dev->ops->read) {
+        return LFS_ERR_IO;
+    }
+
+    /* Enforce LittleFS contract: read confined to a block */
+    if (off + size > c->block_size) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL read exceeds block boundary: off=0x%08x size=0x%08x block_size=0x%08x",
+                 (unsigned)off, (unsigned)size, (unsigned)c->block_size);
+        return LFS_ERR_INVAL;
+    }
+
+    const uint64_t addr = ((uint64_t)block * c->block_size) + off;
+
+#ifdef CONFIG_LITTLEFS_WDT_RESET
+    esp_task_wdt_reset();
+#endif
+
+    if (dev->geometry.disk_size && addr + size > dev->geometry.disk_size) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL read out of range: addr=0x%016" PRIx64 ", size=0x%08x (disk_size=0x%016" PRIx64 ")",
+                 addr, (unsigned)size, dev->geometry.disk_size);
+        return LFS_ERR_IO;
+    }
+
+    esp_err_t err = dev->ops->read(dev, (uint8_t *)buffer, size, addr, size);
+    if (err != ESP_OK) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL read failed: addr=0x%016" PRIx64 ", size=0x%08x, err=0x%x",
+                 addr, (unsigned)size, err);
+    }
+    return esp_err_to_lfs(err);
+}
+
+int littlefs_bdl_write(const struct lfs_config *c, lfs_block_t block,
+                       lfs_off_t off, const void *buffer, lfs_size_t size)
+{
+    esp_littlefs_t *efs = (esp_littlefs_t *)c->context;
+    esp_blockdev_handle_t dev = efs ? efs->bdl_handle : NULL;
+    if (!validate_handle(dev, "write") || !dev->ops->write) {
+        return LFS_ERR_IO;
+    }
+
+    if ((efs && efs->read_only) || dev->device_flags.read_only) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL write rejected: device is read-only");
+        return LFS_ERR_IO;
+    }
+
+    if (off + size > c->block_size) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL write exceeds block boundary: off=0x%08x size=0x%08x block_size=0x%08x",
+                 (unsigned)off, (unsigned)size, (unsigned)c->block_size);
+        return LFS_ERR_INVAL;
+    }
+
+    const uint64_t addr = ((uint64_t)block * c->block_size) + off;
+
+#ifdef CONFIG_LITTLEFS_WDT_RESET
+    esp_task_wdt_reset();
+#endif
+
+    if (dev->geometry.disk_size && addr + size > dev->geometry.disk_size) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL write out of range: addr=0x%016" PRIx64 ", size=0x%08x (disk_size=0x%016" PRIx64 ")",
+                 addr, (unsigned)size, dev->geometry.disk_size);
+        return LFS_ERR_IO;
+    }
+
+    esp_err_t err = dev->ops->write(dev, (const uint8_t *)buffer, addr, size);
+    if (err != ESP_OK) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL write failed: addr=0x%016" PRIx64 ", size=0x%08x, err=0x%x",
+                 addr, (unsigned)size, err);
+    }
+    return esp_err_to_lfs(err);
+}
+
+int littlefs_bdl_erase(const struct lfs_config *c, lfs_block_t block)
+{
+    esp_littlefs_t *efs = (esp_littlefs_t *)c->context;
+    esp_blockdev_handle_t dev = efs ? efs->bdl_handle : NULL;
+    if (!validate_handle(dev, "erase") || !dev->ops->erase) {
+        return LFS_ERR_IO;
+    }
+
+    if ((efs && efs->read_only) || dev->device_flags.read_only || dev->geometry.erase_size == 0) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL erase not supported (read-only or erase_size=0)");
+        return LFS_ERR_IO;
+    }
+
+    const uint64_t addr = (uint64_t)block * c->block_size;
+    const size_t erase_len = c->block_size;
+
+#ifdef CONFIG_LITTLEFS_WDT_RESET
+    esp_task_wdt_reset();
+#endif
+
+    /* Basic alignment check against device geometry if provided */
+    if (dev->geometry.erase_size &&
+        ((addr % dev->geometry.erase_size) || (erase_len % dev->geometry.erase_size))) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL erase misaligned: addr=0x%016" PRIx64 ", len=0x%08x, erase_size=0x%08x",
+                 addr, (unsigned)erase_len, (unsigned)dev->geometry.erase_size);
+        return LFS_ERR_INVAL;
+    }
+
+    if (dev->geometry.disk_size && addr + erase_len > dev->geometry.disk_size) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL erase out of range: addr=0x%016" PRIx64 ", len=0x%08x (disk_size=0x%016" PRIx64 ")",
+                 addr, (unsigned)erase_len, dev->geometry.disk_size);
+        return LFS_ERR_IO;
+    }
+
+    esp_err_t err = dev->ops->erase(dev, addr, erase_len);
+    if (err != ESP_OK) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL erase failed: addr=0x%016" PRIx64 ", len=0x%08x, err=0x%x",
+                 addr, (unsigned)erase_len, err);
+    }
+    return esp_err_to_lfs(err);
+}
+
+int littlefs_bdl_sync(const struct lfs_config *c)
+{
+    esp_littlefs_t *efs = (esp_littlefs_t *)c->context;
+    esp_blockdev_handle_t dev = efs ? efs->bdl_handle : NULL;
+    if (!validate_handle(dev, "sync")) {
+        return LFS_ERR_IO;
+    }
+
+    if (!dev->ops->sync) {
+        return LFS_ERR_OK; /* Nothing to do */
+    }
+
+#ifdef CONFIG_LITTLEFS_WDT_RESET
+    esp_task_wdt_reset();
+#endif
+
+    esp_err_t err = dev->ops->sync(dev);
+    if (err != ESP_OK) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL sync failed: err=0x%x", err);
+    }
+    return esp_err_to_lfs(err);
+}

--- a/src/littlefs_bdl.c
+++ b/src/littlefs_bdl.c
@@ -79,6 +79,7 @@ int littlefs_bdl_read(const struct lfs_config *c, lfs_block_t block,
         return LFS_ERR_IO;
     }
 
+    /* dst_buf_size == data_read_len because LittleFS always provides an exact-sized buffer */
     esp_err_t err = dev->ops->read(dev, (uint8_t *)buffer, size, addr, size);
     if (err != ESP_OK) {
         ESP_LOGE(ESP_LITTLEFS_TAG, "BDL read failed: addr=0x%016" PRIx64 ", size=0x%08x, err=0x%x",

--- a/test/test_littlefs_blockdev.c
+++ b/test/test_littlefs_blockdev.c
@@ -4,12 +4,251 @@
 #include "esp_blockdev.h"
 #include "spi_flash_mmap.h"
 #include "esp_flash.h"
+#include <stdlib.h>
+#include <string.h>
 
 static esp_partition_t get_test_data_static_partition(void);
 static void            test_setup_bdl(const esp_partition_t* partition, bool read_only);
 static void            test_teardown_bdl(void);
 
 static esp_blockdev_handle_t s_bdl_handle = NULL;
+
+/* Mock BDL for geometry/flag validation tests. */
+#define MOCK_BDL_TEST_READ_SIZE   16
+#define MOCK_BDL_TEST_WRITE_SIZE  16
+#define MOCK_BDL_TEST_ERASE_SIZE  512
+#define MOCK_BDL_TEST_BLOCK_COUNT 32
+#define MOCK_BDL_TEST_DISK_SIZE   (MOCK_BDL_TEST_ERASE_SIZE * MOCK_BDL_TEST_BLOCK_COUNT)
+
+typedef struct {
+    uint8_t *storage;
+    size_t disk_size;
+    size_t erase_size;
+    bool strict_erase_alignment;
+    size_t erase_calls;
+    size_t last_erase_len;
+} mock_bdl_ctx_t;
+
+typedef struct {
+    bool read_only;
+    bool encrypted;
+    bool erase_before_write;
+    bool and_type_write;
+    bool default_val_after_erase;
+    size_t read_size;
+    size_t write_size;
+    size_t erase_size;
+    size_t recommended_read_size;
+    size_t recommended_write_size;
+    size_t recommended_erase_size;
+    size_t disk_size;
+    bool strict_erase_alignment;
+} mock_bdl_params_t;
+
+static uint8_t s_mock_bdl_storage[MOCK_BDL_TEST_DISK_SIZE];
+
+static esp_err_t mock_bdl_read(esp_blockdev_handle_t dev_handle, uint8_t *dst_buf,
+                               size_t dst_buf_size, uint64_t src_addr, size_t data_read_len)
+{
+    mock_bdl_ctx_t *ctx = (mock_bdl_ctx_t *)dev_handle->ctx;
+    if (!ctx || !dst_buf || data_read_len > dst_buf_size || src_addr + data_read_len > ctx->disk_size) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    memcpy(dst_buf, &ctx->storage[src_addr], data_read_len);
+    return ESP_OK;
+}
+
+static esp_err_t mock_bdl_write(esp_blockdev_handle_t dev_handle, const uint8_t *src_buf,
+                                uint64_t dst_addr, size_t data_write_len)
+{
+    mock_bdl_ctx_t *ctx = (mock_bdl_ctx_t *)dev_handle->ctx;
+    if (!ctx || !src_buf || dst_addr + data_write_len > ctx->disk_size) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (dev_handle->geometry.write_size == 0) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+    if ((dst_addr % dev_handle->geometry.write_size) || (data_write_len % dev_handle->geometry.write_size)) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    /* Enforce flash-like behavior for this mock: bytes must be erased before programming. */
+    for (size_t i = 0; i < data_write_len; i++) {
+        if (ctx->storage[dst_addr + i] != 0xFF) {
+            return ESP_ERR_INVALID_STATE;
+        }
+    }
+
+    memcpy(&ctx->storage[dst_addr], src_buf, data_write_len);
+    return ESP_OK;
+}
+
+static esp_err_t mock_bdl_erase(esp_blockdev_handle_t dev_handle, uint64_t start_addr, size_t erase_len)
+{
+    mock_bdl_ctx_t *ctx = (mock_bdl_ctx_t *)dev_handle->ctx;
+    if (!ctx || start_addr + erase_len > ctx->disk_size) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (ctx->strict_erase_alignment && ctx->erase_size > 0 &&
+            ((start_addr % ctx->erase_size) || (erase_len % ctx->erase_size))) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    ctx->erase_calls++;
+    ctx->last_erase_len = erase_len;
+    memset(&ctx->storage[start_addr], 0xFF, erase_len);
+    return ESP_OK;
+}
+
+static esp_err_t mock_bdl_sync(esp_blockdev_handle_t dev_handle)
+{
+    (void)dev_handle;
+    return ESP_OK;
+}
+
+static esp_err_t mock_bdl_release(esp_blockdev_handle_t dev_handle)
+{
+    if (!dev_handle) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (dev_handle->ctx) {
+        free(dev_handle->ctx);
+        dev_handle->ctx = NULL;
+    }
+    dev_handle->ops = NULL;
+    return ESP_OK;
+}
+
+static const esp_blockdev_ops_t s_mock_bdl_ops = {
+    .read = mock_bdl_read,
+    .write = mock_bdl_write,
+    .erase = mock_bdl_erase,
+    .sync = mock_bdl_sync,
+    .ioctl = NULL,
+    .release = mock_bdl_release,
+};
+
+static mock_bdl_params_t mock_bdl_default_params(void)
+{
+    return (mock_bdl_params_t){
+        .read_only = false,
+        .encrypted = false,
+        .erase_before_write = true,
+        .and_type_write = true,
+        .default_val_after_erase = true,
+        .read_size = MOCK_BDL_TEST_READ_SIZE,
+        .write_size = MOCK_BDL_TEST_WRITE_SIZE,
+        .erase_size = MOCK_BDL_TEST_ERASE_SIZE,
+        .recommended_read_size = 0,
+        .recommended_write_size = 0,
+        .recommended_erase_size = 0,
+        .disk_size = MOCK_BDL_TEST_DISK_SIZE,
+        .strict_erase_alignment = true,
+    };
+}
+
+static esp_err_t mock_bdl_create_custom(esp_blockdev_handle_t *out, const mock_bdl_params_t *params, bool reset_media)
+{
+    if (!out || !params || params->disk_size == 0 || params->disk_size > sizeof(s_mock_bdl_storage)) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (reset_media) {
+        memset(s_mock_bdl_storage, 0xFF, params->disk_size);
+    }
+
+    esp_blockdev_handle_t dev = calloc(1, sizeof(*dev));
+    mock_bdl_ctx_t *ctx = calloc(1, sizeof(*ctx));
+    if (!dev || !ctx) {
+        free(ctx);
+        free(dev);
+        return ESP_ERR_NO_MEM;
+    }
+
+    ctx->storage = s_mock_bdl_storage;
+    ctx->disk_size = params->disk_size;
+    ctx->erase_size = params->erase_size;
+    ctx->strict_erase_alignment = params->strict_erase_alignment;
+
+    dev->ctx = ctx;
+    dev->device_flags.read_only = params->read_only;
+    dev->device_flags.encrypted = params->encrypted;
+    dev->device_flags.erase_before_write = params->erase_before_write;
+    dev->device_flags.and_type_write = params->and_type_write;
+    dev->device_flags.default_val_after_erase = params->default_val_after_erase;
+    dev->geometry.disk_size = params->disk_size;
+    dev->geometry.read_size = params->read_size;
+    dev->geometry.write_size = params->write_size;
+    dev->geometry.erase_size = params->erase_size;
+    dev->geometry.recommended_read_size = params->recommended_read_size;
+    dev->geometry.recommended_write_size = params->recommended_write_size;
+    dev->geometry.recommended_erase_size = params->recommended_erase_size;
+    dev->ops = &s_mock_bdl_ops;
+
+    *out = dev;
+    return ESP_OK;
+}
+
+static void mock_bdl_destroy_handle(esp_blockdev_handle_t handle)
+{
+    if (!handle) {
+        return;
+    }
+    if (handle->ops && handle->ops->release) {
+        TEST_ESP_OK(handle->ops->release(handle));
+    }
+    free(handle);
+}
+
+static esp_err_t try_register_mock_bdl(const mock_bdl_params_t *params,
+                                       bool mount_read_only,
+                                       bool format_if_mount_failed,
+                                       bool reset_media,
+                                       esp_blockdev_handle_t *out_handle)
+{
+    esp_blockdev_handle_t handle = NULL;
+    esp_err_t err = mock_bdl_create_custom(&handle, params, reset_media);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    const esp_vfs_littlefs_conf_t conf = {
+        .base_path = littlefs_base_path,
+        .partition_label = NULL,
+        .partition = NULL,
+        .blockdev = handle,
+        .dont_mount = false,
+        .read_only = mount_read_only,
+        .format_if_mount_failed = format_if_mount_failed,
+    };
+
+    err = esp_vfs_littlefs_register(&conf);
+    if (err == ESP_OK) {
+        if (out_handle) {
+            *out_handle = handle;
+        } else {
+            TEST_ESP_OK(esp_vfs_littlefs_unregister_blockdev(handle));
+            mock_bdl_destroy_handle(handle);
+        }
+        return err;
+    }
+
+    mock_bdl_destroy_handle(handle);
+    if (out_handle) {
+        *out_handle = NULL;
+    }
+    return err;
+}
+
+static void assert_mock_bdl_register_result(const mock_bdl_params_t *params,
+                                            bool mount_read_only,
+                                            esp_err_t expected)
+{
+    TEST_ASSERT_EQUAL(expected,
+        try_register_mock_bdl(params, mount_read_only, true, true, NULL));
+}
 
 static esp_partition_t get_test_data_static_partition(void)
 {
@@ -196,4 +435,151 @@ TEST_CASE("bdl can format mounted partition", "[littlefs_bdl]")
     TEST_ASSERT_NULL(f);
 
     test_teardown_bdl_rw();
+}
+
+TEST_CASE("bdl flag compatibility validation", "[littlefs_bdl_geom]")
+{
+    mock_bdl_params_t p = mock_bdl_default_params();
+    p.encrypted = true;
+    assert_mock_bdl_register_result(&p, false, ESP_ERR_NOT_SUPPORTED);
+
+    p = mock_bdl_default_params();
+    p.default_val_after_erase = false;
+    assert_mock_bdl_register_result(&p, false, ESP_ERR_NOT_SUPPORTED);
+
+    p = mock_bdl_default_params();
+    p.and_type_write = false;
+    assert_mock_bdl_register_result(&p, false, ESP_OK);
+
+    p = mock_bdl_default_params();
+    p.read_only = true;
+    assert_mock_bdl_register_result(&p, false, ESP_ERR_INVALID_ARG);
+}
+
+TEST_CASE("bdl basic geometry rejection matrix", "[littlefs_bdl_geom]")
+{
+    mock_bdl_params_t p = mock_bdl_default_params();
+    p.read_size = 0;
+    assert_mock_bdl_register_result(&p, false, ESP_ERR_INVALID_ARG);
+
+    p = mock_bdl_default_params();
+    p.erase_before_write = true;
+    p.erase_size = 0;
+    assert_mock_bdl_register_result(&p, false, ESP_ERR_INVALID_ARG);
+
+    p = mock_bdl_default_params();
+    p.erase_before_write = false;
+    p.and_type_write = false;
+    p.write_size = 0;
+    p.strict_erase_alignment = false;
+    assert_mock_bdl_register_result(&p, false, ESP_ERR_INVALID_ARG);
+
+    p = mock_bdl_default_params();
+    p.erase_before_write = false;
+    p.and_type_write = false;
+    p.read_size = 16;
+    p.write_size = 48; /* lcm = 48 */
+    p.disk_size = (48 * 10) - 1;
+    p.strict_erase_alignment = false;
+    assert_mock_bdl_register_result(&p, false, ESP_ERR_INVALID_ARG);
+}
+
+TEST_CASE("bdl classic sector size uses recommended erase size", "[littlefs_bdl_geom]")
+{
+    mock_bdl_params_t p = mock_bdl_default_params();
+    p.erase_before_write = true;
+    p.read_size = 16;
+    p.write_size = 16;
+    p.erase_size = 512;
+    p.recommended_erase_size = 1024;
+    p.disk_size = 1024 * 8;
+
+    esp_blockdev_handle_t handle = NULL;
+    TEST_ASSERT_EQUAL(ESP_OK, try_register_mock_bdl(&p, false, true, true, &handle));
+    TEST_ASSERT_NOT_NULL(handle);
+
+    mock_bdl_ctx_t *ctx = (mock_bdl_ctx_t *)handle->ctx;
+    TEST_ASSERT_NOT_NULL(ctx);
+    TEST_ASSERT_GREATER_THAN(0, ctx->erase_calls);
+    TEST_ASSERT_EQUAL(1024, ctx->last_erase_len);
+
+    TEST_ESP_OK(esp_vfs_littlefs_unregister_blockdev(handle));
+    mock_bdl_destroy_handle(handle);
+}
+
+TEST_CASE("bdl logical sector size uses lcm(read,write)", "[littlefs_bdl_geom]")
+{
+    mock_bdl_params_t p = mock_bdl_default_params();
+    p.erase_before_write = false;
+    p.and_type_write = false;
+    p.read_size = 64;
+    p.write_size = 96; /* lcm = 192 */
+    p.erase_size = 4096; /* ignored for logical mode sizing */
+    p.disk_size = 192 * 20;
+    p.strict_erase_alignment = false;
+
+    esp_blockdev_handle_t handle = NULL;
+    TEST_ASSERT_EQUAL(ESP_OK, try_register_mock_bdl(&p, false, true, true, &handle));
+    TEST_ASSERT_NOT_NULL(handle);
+
+    mock_bdl_ctx_t *ctx = (mock_bdl_ctx_t *)handle->ctx;
+    TEST_ASSERT_NOT_NULL(ctx);
+    TEST_ASSERT_GREATER_THAN(0, ctx->erase_calls);
+    TEST_ASSERT_EQUAL(192, ctx->last_erase_len);
+
+    TEST_ESP_OK(esp_vfs_littlefs_unregister_blockdev(handle));
+    mock_bdl_destroy_handle(handle);
+}
+
+TEST_CASE("duplicate blockdev registration keeps existing mount intact", "[littlefs_bdl_geom]")
+{
+    mock_bdl_params_t p = mock_bdl_default_params();
+    esp_blockdev_handle_t handle = NULL;
+    TEST_ESP_OK(mock_bdl_create_custom(&handle, &p, true));
+    TEST_ASSERT_NOT_NULL(handle);
+
+    const esp_vfs_littlefs_conf_t conf = {
+        .base_path = littlefs_base_path,
+        .partition_label = NULL,
+        .partition = NULL,
+        .blockdev = handle,
+        .dont_mount = false,
+        .read_only = false,
+        .format_if_mount_failed = true,
+    };
+
+    TEST_ESP_OK(esp_vfs_littlefs_register(&conf));
+    TEST_ASSERT_TRUE(esp_littlefs_blockdev_mounted(handle));
+
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_STATE, esp_vfs_littlefs_register(&conf));
+    TEST_ASSERT_TRUE(esp_littlefs_blockdev_mounted(handle));
+    TEST_ESP_OK(esp_vfs_littlefs_unregister_blockdev(handle));
+
+    mock_bdl_destroy_handle(handle);
+}
+
+TEST_CASE("format blockdev does not consume caller handle", "[littlefs_bdl_geom]")
+{
+    mock_bdl_params_t p = mock_bdl_default_params();
+    esp_blockdev_handle_t handle = NULL;
+    TEST_ESP_OK(mock_bdl_create_custom(&handle, &p, true));
+    TEST_ASSERT_NOT_NULL(handle);
+
+    TEST_ESP_OK(esp_littlefs_format_blockdev(handle));
+    TEST_ASSERT_NOT_NULL(handle->ops);
+
+    const esp_vfs_littlefs_conf_t conf = {
+        .base_path = littlefs_base_path,
+        .partition_label = NULL,
+        .partition = NULL,
+        .blockdev = handle,
+        .dont_mount = false,
+        .read_only = false,
+        .format_if_mount_failed = true,
+    };
+
+    TEST_ESP_OK(esp_vfs_littlefs_register(&conf));
+    TEST_ESP_OK(esp_vfs_littlefs_unregister_blockdev(handle));
+
+    mock_bdl_destroy_handle(handle);
 }

--- a/test/test_littlefs_blockdev.c
+++ b/test/test_littlefs_blockdev.c
@@ -1,0 +1,199 @@
+// Tests for LittleFS mounted via esp_blockdev handle
+#include "test_littlefs_common.h"
+#include "esp_partition.h"
+#include "esp_blockdev.h"
+#include "spi_flash_mmap.h"
+#include "esp_flash.h"
+
+static esp_partition_t get_test_data_static_partition(void);
+static void            test_setup_bdl(const esp_partition_t* partition, bool read_only);
+static void            test_teardown_bdl(void);
+
+static esp_blockdev_handle_t s_bdl_handle = NULL;
+
+static esp_partition_t get_test_data_static_partition(void)
+{
+    /* Construct a partition descriptor for the embedded testfs binary */
+    extern const uint8_t partition_blob_start[] asm("_binary_testfs_bin_start");
+    extern const uint8_t partition_blob_end[] asm("_binary_testfs_bin_end");
+
+    return (esp_partition_t){
+        .flash_chip = esp_flash_default_chip,
+        .type       = ESP_PARTITION_TYPE_DATA,
+        .subtype    = ESP_PARTITION_SUBTYPE_DATA_FAT,
+        .address    = spi_flash_cache2phys(partition_blob_start),
+        .size       = ((uint32_t)partition_blob_end) - ((uint32_t)partition_blob_start),
+        .erase_size = SPI_FLASH_SEC_SIZE, /* match flash sector & embedded LittleFS image block size */
+        .label      = "",
+        .encrypted  = false,
+        .readonly   = false,
+    };
+}
+
+static void test_setup_bdl(const esp_partition_t* partition, bool read_only)
+{
+    TEST_ESP_OK(esp_partition_ptr_get_blockdev(partition, &s_bdl_handle));
+
+    const esp_vfs_littlefs_conf_t conf = {
+        .base_path  = littlefs_base_path,
+        .partition_label = NULL,
+        .partition  = NULL,
+        .blockdev   = s_bdl_handle,
+        .dont_mount = false,
+        .read_only  = read_only,
+    };
+
+    TEST_ESP_OK(esp_vfs_littlefs_register(&conf));
+    TEST_ASSERT_TRUE(heap_caps_check_integrity_all(true));
+    TEST_ASSERT_TRUE(esp_littlefs_blockdev_mounted(s_bdl_handle));
+    printf("BDL test setup complete.\n");
+}
+
+static void test_teardown_bdl(void)
+{
+    TEST_ESP_OK(esp_vfs_littlefs_unregister_blockdev(s_bdl_handle));
+    TEST_ASSERT_TRUE(heap_caps_check_integrity_all(true));
+    s_bdl_handle = NULL; // released by unregister
+    printf("BDL test teardown complete.\n");
+}
+
+static const esp_partition_t* get_rw_partition(void)
+{
+    const esp_partition_t *part = esp_partition_find_first(
+        ESP_PARTITION_TYPE_DATA,
+        ESP_PARTITION_SUBTYPE_DATA_LITTLEFS,
+        littlefs_test_partition_label);
+    if (!part) {
+        part = esp_partition_find_first(
+            ESP_PARTITION_TYPE_DATA,
+            ESP_PARTITION_SUBTYPE_ANY,
+            littlefs_test_partition_label);
+    }
+    TEST_ASSERT_NOT_NULL_MESSAGE(part, "littlefs test partition not found");
+    return part;
+}
+
+static void test_setup_bdl_rw(void)
+{
+    const esp_partition_t *part = get_rw_partition();
+    /* Format via partition API to ensure clean media before blockdev mount */
+    TEST_ESP_OK(esp_littlefs_format_partition(part));
+
+    TEST_ESP_OK(esp_partition_ptr_get_blockdev(part, &s_bdl_handle));
+
+    const esp_vfs_littlefs_conf_t conf = {
+        .base_path  = littlefs_base_path,
+        .partition_label = NULL,
+        .partition  = NULL,
+        .blockdev   = s_bdl_handle,
+        .dont_mount = false,
+        .read_only  = false,
+        .format_if_mount_failed = true,
+    };
+
+    TEST_ESP_OK(esp_vfs_littlefs_register(&conf));
+    TEST_ASSERT_TRUE(heap_caps_check_integrity_all(true));
+    TEST_ASSERT_TRUE(esp_littlefs_blockdev_mounted(s_bdl_handle));
+    printf("BDL RW setup complete.\n");
+}
+
+static void test_teardown_bdl_rw(void)
+{
+    TEST_ESP_OK(esp_vfs_littlefs_unregister_blockdev(s_bdl_handle));
+    TEST_ASSERT_TRUE(heap_caps_check_integrity_all(true));
+    s_bdl_handle = NULL;
+    printf("BDL RW teardown complete.\n");
+}
+
+TEST_CASE("bdl can initialize LittleFS in erased partition", "[littlefs_bdl]")
+{
+    const esp_partition_t *part = get_rw_partition();
+    TEST_ESP_OK(esp_littlefs_format_partition(part));
+    test_setup_bdl_rw();
+
+    size_t total = 0, used = 0;
+    TEST_ESP_OK(esp_littlefs_blockdev_info(s_bdl_handle, &total, &used));
+    TEST_ASSERT_GREATER_THAN(0, total);
+
+    test_teardown_bdl_rw();
+}
+
+TEST_CASE("bdl can read file", "[littlefs_bdl]")
+{
+    const esp_partition_t partition = get_test_data_static_partition();
+    test_setup_bdl(&partition, true);
+
+    test_littlefs_read_file_with_content(littlefs_base_path "/test1.txt", "test1");
+    test_littlefs_read_file_with_content(littlefs_base_path "/test2.txt", "test2");
+    test_littlefs_read_file_with_content(littlefs_base_path "/pangram.txt", "The quick brown fox jumps over the lazy dog");
+
+    test_teardown_bdl();
+}
+
+TEST_CASE("bdl cannot create file when mounted read-only", "[littlefs_bdl]")
+{
+    const esp_partition_t partition = get_test_data_static_partition();
+    test_setup_bdl(&partition, true);
+
+    FILE* f = fopen(littlefs_base_path "/new_file.txt", "wb");
+    TEST_ASSERT_NULL(f);
+
+    test_teardown_bdl();
+}
+
+TEST_CASE("bdl cannot delete existing file when mounted read-only", "[littlefs_bdl]")
+{
+    const esp_partition_t partition = get_test_data_static_partition();
+    test_setup_bdl(&partition, true);
+
+    TEST_ASSERT_EQUAL(-1, unlink(littlefs_base_path "/test1.txt"));
+    test_littlefs_read_file_with_content(littlefs_base_path "/test1.txt", "test1");
+
+    test_teardown_bdl();
+}
+
+TEST_CASE("bdl can create and read file", "[littlefs_bdl]")
+{
+    test_setup_bdl_rw();
+
+    const char *fn = littlefs_base_path "/hello.txt";
+    test_littlefs_create_file_with_text(fn, littlefs_test_hello_str);
+    test_littlefs_read_file(fn);
+
+    test_teardown_bdl_rw();
+}
+
+TEST_CASE("bdl cannot write existing file when mounted read-only", "[littlefs_bdl]")
+{
+    const esp_partition_t partition = get_test_data_static_partition();
+    test_setup_bdl(&partition, true);
+
+    FILE* f = fopen(littlefs_base_path "/test1.txt", "wb");
+    TEST_ASSERT_NULL(f);
+    test_littlefs_read_file_with_content(littlefs_base_path "/test1.txt", "test1");
+
+    test_teardown_bdl();
+}
+
+TEST_CASE("bdl can format mounted partition", "[littlefs_bdl]")
+{
+    const esp_partition_t *part = get_rw_partition();
+    /* start clean */
+    TEST_ESP_OK(esp_littlefs_format_partition(part));
+    test_setup_bdl_rw();
+
+    /* write a file then format via BDL path */
+    const char *fn = littlefs_base_path "/hello.txt";
+    test_littlefs_create_file_with_text(fn, littlefs_test_hello_str);
+
+    /* unmount then format underlying partition */
+    test_teardown_bdl_rw();
+    TEST_ESP_OK(esp_littlefs_format_partition(part));
+
+    /* mount again and ensure file is gone */
+    test_setup_bdl_rw();
+    FILE *f = fopen(fn, "r");
+    TEST_ASSERT_NULL(f);
+
+    test_teardown_bdl_rw();
+}

--- a/test/test_littlefs_blockdev.c
+++ b/test/test_littlefs_blockdev.c
@@ -22,7 +22,7 @@ static esp_partition_t get_test_data_static_partition(void)
         .type       = ESP_PARTITION_TYPE_DATA,
         .subtype    = ESP_PARTITION_SUBTYPE_DATA_FAT,
         .address    = spi_flash_cache2phys(partition_blob_start),
-        .size       = ((uint32_t)partition_blob_end) - ((uint32_t)partition_blob_start),
+        .size       = ((uintptr_t)partition_blob_end) - ((uintptr_t)partition_blob_start),
         .erase_size = SPI_FLASH_SEC_SIZE, /* match flash sector & embedded LittleFS image block size */
         .label      = "",
         .encrypted  = false,

--- a/test_apps/main/CMakeLists.txt
+++ b/test_apps/main/CMakeLists.txt
@@ -1,25 +1,36 @@
 set(TEST_DIR "${CMAKE_CURRENT_LIST_DIR}/../../test")
 
+set(MAIN_TEST_SRCS
+    "test_main.c"
+    "${TEST_DIR}/test_littlefs.c"
+    "${TEST_DIR}/test_littlefs_common.c"
+    "${TEST_DIR}/test_dir.c"
+    "${TEST_DIR}/test_benchmark.c"
+    "${TEST_DIR}/test_littlefs_static_partition.c"
+)
+
+set(MAIN_TEST_REQUIRES
+    esp_littlefs
+    unity
+    test_utils
+    vfs
+    spi_flash
+    spiffs
+    fatfs
+    wear_levelling
+    esp_timer
+    esp_partition
+)
+
+if(NOT IDF_TARGET STREQUAL "esp8266" AND "${IDF_VERSION_MAJOR}" VERSION_GREATER_EQUAL "6")
+    list(APPEND MAIN_TEST_SRCS "${TEST_DIR}/test_littlefs_blockdev.c")
+    list(APPEND MAIN_TEST_REQUIRES esp_blockdev)
+endif()
+
 idf_component_register(
-    SRCS
-        "test_main.c"
-        "${TEST_DIR}/test_littlefs.c"
-        "${TEST_DIR}/test_littlefs_common.c"
-        "${TEST_DIR}/test_dir.c"
-        "${TEST_DIR}/test_benchmark.c"
-        "${TEST_DIR}/test_littlefs_static_partition.c"
+    SRCS ${MAIN_TEST_SRCS}
     INCLUDE_DIRS "${TEST_DIR}"
-    PRIV_REQUIRES
-        esp_littlefs
-        unity
-        test_utils
-        vfs
-        spi_flash
-        spiffs
-        fatfs
-        wear_levelling
-        esp_timer
-        esp_partition
+    PRIV_REQUIRES ${MAIN_TEST_REQUIRES}
     WHOLE_ARCHIVE
 )
 


### PR DESCRIPTION
Since ESP-IDF v5.5, a generic block device layer has been available.
In v6.0, this was extended to support esp_partition and other native ESP32 storage options.
This makes it possible to access all storage media through a single generic API.
There will be a push in the future to deprecate the previous custom APIs for each storage device in favor of the generic BDL.

This PR adds support for that API to LittleFS.