### PR TITLE
Switch PSRAM mode to use prefer malloc/calloc

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -250,7 +250,6 @@ menu "LittleFS"
 
         config LITTLEFS_MALLOC_STRATEGY_SPIRAM_PREFER
             bool "SPIRAM heap, fall back to default heap"
-            depends on SPIRAM_USE_MALLOC || SPIRAM_USE_CAPS_ALLOC
             help
                 Uses ESP-IDF heap_caps_malloc_prefer to allocate from SPIRAM heap,
                 falling back to the default heap (typically internal RAM) if the

--- a/Kconfig
+++ b/Kconfig
@@ -246,6 +246,16 @@ menu "LittleFS"
             depends on SPIRAM_USE_MALLOC || SPIRAM_USE_CAPS_ALLOC
             help
                 Uses ESP-IDF heap_caps_malloc to allocate from SPIRAM heap.
+                Allocation fails if SPIRAM is exhausted; internal heap is not used.
+
+        config LITTLEFS_MALLOC_STRATEGY_SPIRAM_PREFER
+            bool "SPIRAM heap, fall back to default heap"
+            depends on SPIRAM_USE_MALLOC || SPIRAM_USE_CAPS_ALLOC
+            help
+                Uses ESP-IDF heap_caps_malloc_prefer to allocate from SPIRAM heap,
+                falling back to the default heap (typically internal RAM) if the
+                SPIRAM allocation fails. Choose this when you want SPIRAM to be
+                used opportunistically without hard-failing under SPIRAM pressure.
 
     endchoice
 

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -180,7 +180,7 @@ static inline void * esp_littlefs_calloc(size_t __nmemb, size_t __size) {
 #if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL)
     return heap_caps_calloc(__nmemb, __size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
 #elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
-    return heap_caps_calloc(__nmemb, __size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
+    return heap_caps_calloc_prefer(__nmemb, __size, 2, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM, MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
 #else /* CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE, CONFIG_LITTLEFS_MALLOC_STRATEGY_DEFAULT or not defined */
     return calloc(__nmemb, __size);
 #endif

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -180,6 +180,8 @@ static inline void * esp_littlefs_calloc(size_t __nmemb, size_t __size) {
 #if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL)
     return heap_caps_calloc(__nmemb, __size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
 #elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
+    return heap_caps_calloc(__nmemb, __size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
+#elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM_PREFER)
     return heap_caps_calloc_prefer(__nmemb, __size, 2, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM, MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
 #else /* CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE, CONFIG_LITTLEFS_MALLOC_STRATEGY_DEFAULT or not defined */
     return calloc(__nmemb, __size);

--- a/src/lfs_config.h
+++ b/src/lfs_config.h
@@ -218,7 +218,7 @@ static inline void *lfs_malloc(size_t size) {
 #elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL)
     return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
 #elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
-    return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
+    return heap_caps_malloc_prefer(size, 2, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM, MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
 #else // CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE or not defined
     (void)size;
     return NULL;

--- a/src/lfs_config.h
+++ b/src/lfs_config.h
@@ -218,6 +218,8 @@ static inline void *lfs_malloc(size_t size) {
 #elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL)
     return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_INTERNAL);
 #elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
+    return heap_caps_malloc(size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
+#elif defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM_PREFER)
     return heap_caps_malloc_prefer(size, 2, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM, MALLOC_CAP_8BIT | MALLOC_CAP_DEFAULT);
 #else // CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE or not defined
     (void)size;
@@ -229,7 +231,8 @@ static inline void *lfs_malloc(size_t size) {
 static inline void lfs_free(void *p) {
 #if defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_DEFAULT) || \
     defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_INTERNAL) || \
-    defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM)
+    defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM) || \
+    defined(CONFIG_LITTLEFS_MALLOC_STRATEGY_SPIRAM_PREFER)
     free(p);
 #else // CONFIG_LITTLEFS_MALLOC_STRATEGY_DISABLE or not defined
     (void)p;


### PR DESCRIPTION

Switching to use the "prefer" API as it allows providing a fallback capability when there is a failure.

The first capability that returns a non-null value will end up as used, if the method returns a null value then the allocation failed entirely which is the same behavior as used previously. For releasing the allocated memory, the existing API call is safe to use.

Fix for https://github.com/joltwallet/esp_littlefs/issues/258.