### PR TITLE
Fix esp_littlefs_init_blockdev so it switches to logical mode can be used with SD cards as well

### DIFF
--- a/include/esp_littlefs.h
+++ b/include/esp_littlefs.h
@@ -57,10 +57,11 @@ typedef struct {
      *
      * `device_flags` on the handle are validated at mount:
      * - `encrypted` — mount fails (not supported).
-     * - `default_val_after_erase` — must be 1 (LittleFS expects 0xFF after erase).
      * - `erase_before_write` and `and_type_write` are used only to select block sizing mode:
      *   - classic mode (either flag set): `lfs` `block_size` uses geometry erase size.
      *   - logical mode (both flags clear): `lfs` `block_size` uses lcm(read, prog).
+     * - `default_val_after_erase` — must be 1 in classic mode (LittleFS expects 0xFF after
+     *   erase); ignored in logical mode (overwrite-capable media may erase to any value).
      *
      * If the device provides `ops->release`, it is called when the filesystem is torn down
      * (e.g. `esp_vfs_littlefs_unregister_blockdev`).

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -1160,12 +1160,6 @@ static esp_err_t esp_littlefs_init_blockdev(esp_littlefs_t** efs, esp_blockdev_h
         return ESP_ERR_NOT_SUPPORTED;
     }
 
-    /* LittleFS assumes erased storage reads as 0xFF (all bits 1). */
-    if (!f->default_val_after_erase) {
-        ESP_LOGE(ESP_LITTLEFS_TAG, "BDL requires default_val_after_erase=1 (0xFF erased state)");
-        return ESP_ERR_NOT_SUPPORTED;
-    }
-
     /*
      * Use BDL flags only to determine effective LittleFS block sizing mode:
      * - classic: any erase-dependent/program-constrained medium
@@ -1173,6 +1167,18 @@ static esp_err_t esp_littlefs_init_blockdev(esp_littlefs_t** efs, esp_blockdev_h
      */
     const bool classic = f->erase_before_write || f->and_type_write;
     const bool logical = !classic;
+
+    /*
+     * Classic mode packs several commits into a single (large) erase block and relies on
+     * erased storage reading back as 0xFF (all bits 1) to find the end of the log and to
+     * append without re-erasing. In logical mode block_size == prog_size, so every block is
+     * erased and fully re-programmed before it is read again and the erased byte value is
+     * irrelevant (this matches the native SD/eMMC path, which may erase to 0x00).
+     */
+    if (classic && !f->default_val_after_erase) {
+        ESP_LOGE(ESP_LITTLEFS_TAG, "Classic-mode BDL requires default_val_after_erase=1 (0xFF erased state)");
+        return ESP_ERR_NOT_SUPPORTED;
+    }
 
     if (!read_only && blockdev->device_flags.read_only) {
         ESP_LOGE(ESP_LITTLEFS_TAG, "Refusing to mount read-only block dev for write");

--- a/src/esp_littlefs.c
+++ b/src/esp_littlefs.c
@@ -1171,9 +1171,11 @@ static esp_err_t esp_littlefs_init_blockdev(esp_littlefs_t** efs, esp_blockdev_h
     /*
      * Classic mode packs several commits into a single (large) erase block and relies on
      * erased storage reading back as 0xFF (all bits 1) to find the end of the log and to
-     * append without re-erasing. In logical mode block_size == prog_size, so every block is
-     * erased and fully re-programmed before it is read again and the erased byte value is
-     * irrelevant (this matches the native SD/eMMC path, which may erase to 0x00).
+     * append without re-erasing. Logical-mode media are overwrite-capable (no
+     * erase-before-write, no AND-type writes), so LittleFS can program any region
+     * regardless of its current content, and unprogrammed regions are rejected by commit
+     * CRCs — the erased byte value is irrelevant (this matches the native SD/eMMC path,
+     * which may erase to 0x00).
      */
     if (classic && !f->default_val_after_erase) {
         ESP_LOGE(ESP_LITTLEFS_TAG, "Classic-mode BDL requires default_val_after_erase=1 (0xFF erased state)");

--- a/test/test_littlefs_blockdev.c
+++ b/test/test_littlefs_blockdev.c
@@ -447,6 +447,14 @@ TEST_CASE("bdl flag compatibility validation", "[littlefs_bdl_geom]")
     p.default_val_after_erase = false;
     assert_mock_bdl_register_result(&p, false, ESP_ERR_NOT_SUPPORTED);
 
+    /* logical mode does not require a 0xFF erased state (e.g. SD cards erasing to 0x00) */
+    p = mock_bdl_default_params();
+    p.erase_before_write = false;
+    p.and_type_write = false;
+    p.default_val_after_erase = false;
+    p.strict_erase_alignment = false;
+    assert_mock_bdl_register_result(&p, false, ESP_OK);
+
     p = mock_bdl_default_params();
     p.and_type_write = false;
     assert_mock_bdl_register_result(&p, false, ESP_OK);


### PR DESCRIPTION
When trying to use esp_littlefs with BDL init (`esp_littlefs_init_blockdev`) with BDL device created upon an SD `card,` the init fails here:
https://github.com/joltwallet/esp_littlefs/blob/7b72caff1de089598a9b5b0b15a7226b790f3c96/src/esp_littlefs.c#L1163-L1167

This fix changes the mode let's the init function to change the mode from classical to logical before the check and therefore work with SD cards. Tested on real hardware (ESP32-S3 USB OTG devkit).

@BrianPugh could you please look at this? Thank you very much!